### PR TITLE
feat(pipeline): add census acs 5-year estimates etl

### DIFF
--- a/data-pipeline/environment.yaml
+++ b/data-pipeline/environment.yaml
@@ -7,3 +7,4 @@ dependencies:
   - conda-forge::geopandas=1
   - conda-forge::types-requests
   - conda-forge::autopep8
+  - conda-forge::python-dotenv

--- a/data-pipeline/src/etl/convert.py
+++ b/data-pipeline/src/etl/convert.py
@@ -1,0 +1,25 @@
+import pandas
+
+
+def convert_string_columns_to_numeric(df: pandas.DataFrame) -> pandas.DataFrame:
+    """
+    Converts string columns with numbers to int or float in a Pandas DataFrame.
+    Prefers int unless the column contains float values.
+    """
+    for column in df.columns:
+        if df[column].dtype == "object":
+            try:
+                # attempt to convert to numeric (int64 or float64)
+                numeric_series = pandas.to_numeric(df[column], errors="raise")
+
+                # check if the series contains any float values
+                if (numeric_series % 1 == 0).all():
+                    # convert to int if all values are integers
+                    df[column] = numeric_series.astype(int)
+                else:
+                    # otherwise, convert to float
+                    df[column] = numeric_series.astype(float)
+            except ValueError:
+                # if conversion fails, leave the column as is
+                pass
+    return df

--- a/data-pipeline/src/etl/downloader.py
+++ b/data-pipeline/src/etl/downloader.py
@@ -21,7 +21,7 @@ class Downloader:
         self.file_url = file_url
         self.download_file_name = download_file_name
 
-    def download(self, verify: bool = True) -> Self:
+    def download(self, verify: bool = True, replace: bool = True) -> Self:
         """
         Download a file from a URL and save it to a specified location.
 
@@ -29,7 +29,13 @@ class Downloader:
             file_url (str): The URL of the file to download.
             download_file_name (str): The name of the file to save the downloaded content as.
             verify (bool): Whether to verify the SSL certificate. Defaults to True.
+            replace (bool): Whether to replace the existing file. Defaults to True.
         """
+
+        # if the file already exists and replace is False, do not re-download
+        if os.path.exists(self.download_file_name) and not replace:
+            print(f"{self.download_file_name} already exists. Skipping download.")
+            return self
 
         # create the destination directory if it doesn't exist
         os.makedirs(os.path.dirname(self.download_file_name), exist_ok=True)

--- a/data-pipeline/src/etl/downloader.py
+++ b/data-pipeline/src/etl/downloader.py
@@ -42,7 +42,10 @@ class Downloader:
 
         # delete the file/folder if it already exists
         if os.path.exists(self.download_file_name):
-            shutil.rmtree(self.download_file_name)
+            if os.path.isfile(self.download_file_name):
+                os.remove(self.download_file_name)
+            else:
+                shutil.rmtree(self.download_file_name)
 
         try:
             response = requests.get(self.file_url, verify=verify)

--- a/data-pipeline/src/etl/merge.py
+++ b/data-pipeline/src/etl/merge.py
@@ -1,0 +1,47 @@
+import json
+
+
+def merge_json_array_files(
+    json_files: list[str], output_file: str, indent: int = 2, object_merge_keys: list[str] = ['GEOID', 'YEAR']
+) -> None:
+    """
+    Merge multiple JSON array files into a single JSON array file.
+    The merged file will contain all objects from the input files,
+    with objects that share the same values of the merge keys
+    combined.
+
+    Args:
+        json_files (list[str]): List of paths to the input JSON array files.
+        output_file (str): Path to the output merged JSON array file.
+        indent (int): Indentation level for the output JSON file. Default is 2.
+        object_merge_keys (list[str]): List of keys to identify objects to combine. Default is ['GEOID', 'YEAR'].
+    """
+    merged_data = {}
+
+    # Read each JSON file and merge the data
+    for json_file in json_files:
+
+        # open the json file and load the data
+        with open(json_file, 'r') as file:
+            data = json.load(file)
+
+            # iterate through each object in the JSON array
+            for obj in data:
+                # create a unique key for the object based on the merge keys
+                merge_key = tuple(obj[key] for key in object_merge_keys)
+
+                # if a matching object is not found, add the object to the merged data
+                if merge_key not in merged_data:
+                    merged_data[merge_key] = obj
+
+                # otherwise, add the object's data to the existing object
+                else:
+                    for key, value in obj.items():
+                        # warning: this will overwrite existing values
+                        # if the key already exists in the merged object
+                        merged_data[merge_key][key] = value
+
+    # write the merged data to the output file
+    with open(output_file, 'w') as file:
+        json.dump(list(merged_data.values()), file,
+                  sort_keys=True, indent=indent)

--- a/data-pipeline/src/etl/runner.py
+++ b/data-pipeline/src/etl/runner.py
@@ -1,5 +1,7 @@
 
 
+from etl.merge import merge_json_array_files
+from etl.sources.census_acs_5year.etl import CensusACS5YearEstimatesETL
 from etl.sources.greenlink_gtfs.etl import GreentlinkGtfsETL
 
 
@@ -8,4 +10,34 @@ def etl_runner():
     Run the ETL (extract, transform, and load) pipeline for all sources.
     """
 
+    # get Greenlink data
     GreentlinkGtfsETL().run()
+
+    # get Census ACS 5-Year Estimates data
+    s0101 = CensusACS5YearEstimatesETL('S0101')\
+        .run()\
+        .prune_tables()\
+        .to_time_series()
+    dp05 = CensusACS5YearEstimatesETL('DP05')\
+        .run()\
+        .prune_tables()\
+        .to_time_series()
+    s1501 = CensusACS5YearEstimatesETL('S1501')\
+        .run()\
+        .prune_tables()\
+        .to_time_series()
+    b08201 = CensusACS5YearEstimatesETL('B08201')\
+        .run()\
+        .prune_tables()\
+        .to_time_series()
+
+    # merge all Census ACS 5-Year Estimates data into a single time series file
+    merge_json_array_files(
+        json_files=[
+            s0101.time_series_file_path,
+            dp05.time_series_file_path,
+            s1501.time_series_file_path,
+            b08201.time_series_file_path
+        ],
+        output_file='./data/census_acs_5year/time_series.json'
+    )

--- a/data-pipeline/src/etl/sources/census_acs_5year/constants.py
+++ b/data-pipeline/src/etl/sources/census_acs_5year/constants.py
@@ -1,0 +1,75 @@
+from typing import List, Literal, Optional, Tuple, TypedDict
+
+CensusDataTableName = Literal['S0101', 'DP05', 'S1501', 'B08201']
+CensusTableColumns = List[Tuple[str, str]]
+
+
+class CensusDataTableInfo(TypedDict):
+    label: str
+    years: list[int]
+    data: str
+    metadata: str
+    variables: str
+    columns: Optional[CensusTableColumns]
+
+
+tables: dict[CensusDataTableName, CensusDataTableInfo] = {
+    'S0101': {
+        'label': 'Age and Sex',
+        'years': [2019, 2020, 2021, 2022, 2023],
+        'data': "https://api.census.gov/data/{year}/acs/acs5/subject?get=group(S0101)&ucgid=pseudo(0500000US45045$1400000)",
+        'metadata': 'https://api.census.gov/data/{year}/acs/acs5/subject',
+        'variables': 'https://api.census.gov/data/{year}/acs/acs5/subject/variables',
+        'columns': [
+            ('S0101_C01_001E', 'population__total')
+        ]
+    },
+    'DP05': {
+        'label': 'ACS Demographic and Housing Estimates',
+        'years': [2019, 2020, 2021, 2022, 2023],
+        'data': 'https://api.census.gov/data/{year}/acs/acs5/profile?get=group(DP05)&ucgid=pseudo(0500000US45045$1400000)',
+        'metadata': 'https://api.census.gov/data/{year}/acs/acs5/profile',
+        'variables': 'https://api.census.gov/data/{year}/acs/acs5/profile/variables',
+        'columns': [
+            ('DP05_0077E', 'race_ethnicity__white_alone'),
+            ('DP05_0078E', 'race_ethnicity__black_alone'),
+            ('DP05_0079E', 'race_ethnicity__native_alone'),
+            ('DP05_0080E', 'race_ethnicity__asian_alone'),
+            ('DP05_0081E', 'race_ethnicity__pacific_islander_alone'),
+            ('DP05_0082E', 'race_ethnicity__other_alone'),
+            ('DP05_0083E', 'race_ethnicity__multiple'),
+            ('DP05_0071E', 'race_ethnicity__hispanic'),
+        ]
+    },
+    'S1501': {
+        'label': 'Educational Attainment',
+        'years': [2019, 2020, 2021, 2022, 2023],
+        'data': 'https://api.census.gov/data/{year}/acs/acs5/subject?get=group(S1501)&ucgid=pseudo(0500000US45045$1400000)',
+        'metadata': 'https://api.census.gov/data/{year}/acs/acs5/subject',
+        'variables': 'https://api.census.gov/data/{year}/acs/acs5/subject/variables',
+        'columns': [
+            ('S1501_C01_007E', 'educational_attainment__no_high_school'),
+            ('S1501_C01_008E', 'educational_attainment__some_high_school'),
+            ('S1501_C01_009E', 'educational_attainment__high_school_graduate_or_equivalent'),
+            ('S1501_C01_010E', 'educational_attainment__some_college'),
+            ('S1501_C01_011E', 'educational_attainment__associate_degree'),
+            ('S1501_C01_012E', 'educational_attainment__bachelor_degree'),
+            ('S1501_C01_013E', 'educational_attainment__graduate_or_professional_degree'),
+        ]
+    },
+    'B08201': {
+        'label': 'Household Size by Vehicles Available',
+        'years': [2019, 2020, 2021, 2022, 2023],
+        'data': 'https://api.census.gov/data/{year}/acs/acs5?get=group(B08201)&ucgid=pseudo(0500000US45045$1400000)',
+        'metadata': 'https://api.census.gov/data/{year}/acs/acs5',
+        'variables': 'https://api.census.gov/data/{year}/acs/acs5/variables',
+        'columns': [
+            ('B08201_001E', 'households__total'),
+            ('B08201_002E', 'households__no_vehicle'),
+            ('B08201_003E', 'households__1_vehicle'),
+            ('B08201_004E', 'households__2_vehicles'),
+            ('B08201_005E', 'households__3_vehicles'),
+            ('B08201_006E', 'households__4_plus_vehicles'),
+        ]
+    }
+}

--- a/data-pipeline/src/etl/sources/census_acs_5year/etl.py
+++ b/data-pipeline/src/etl/sources/census_acs_5year/etl.py
@@ -1,0 +1,250 @@
+import csv
+import json
+import os
+import shutil
+from typing import Literal, Optional, Self
+
+import pandas
+
+from etl.convert import convert_string_columns_to_numeric
+from etl.downloader import Downloader
+from etl.sources.census_acs_5year.constants import (CensusDataTableInfo,
+                                                    CensusDataTableName,
+                                                    tables)
+
+VariableLabels = dict[str, dict[Literal['label', 'concept'], str]]
+
+
+class CensusACS5YearEstimatesETL:
+    table: CensusDataTableName
+    table_info: CensusDataTableInfo
+    table_folder_path: str
+    download_directory: str = './data/census_acs_5year'
+    years: list[int]
+    api_key: str = os.getenv('CENSUS_API_KEY') or ''
+    time_series_file_path: str
+
+    def __init__(self, table: CensusDataTableName):
+        self.table = table
+        self.table_info = tables[table]
+        self.table_folder_path = f'{self.download_directory}/{self.table}'
+        self.time_series_file_path = f'{self.table_folder_path}/time_series.json'
+
+    def run(self, years: Optional[list[int]] = None) -> Self:
+        if years is None:
+            years = self.table_info['years']
+        self.years = years
+
+        self._download()
+        self._get_variable_labels()
+
+        return self
+
+    def _download(self) -> None:
+        """
+        Download the Census ACS 5-Year Estimates data for the specified years.
+
+        Args:
+            years (list[int]): List of years to download data for. 
+        """
+
+        # if the directory for this table already exists, delete it
+        if os.path.exists(self.table_folder_path):
+            shutil.rmtree(self.table_folder_path)
+
+        # download the data for each year
+        for year in self.years:
+            url = self.table_info['data'].format(
+                year=year) + f'&key={self.api_key}'
+            download_file_path = f'{self.table_folder_path}/{year - 4}-{year}.json'
+
+            print(f"Downloading data from {url}")
+            Downloader(
+                url,
+                download_file_path
+            ).download()
+
+            convert_census_lenght1_2d_array_to_object_array(download_file_path)
+
+    def _get_variable_labels(self) -> None:
+        """
+        Get the variable labels for the specified table.
+
+        Returns:
+            pandas.DataFrame: DataFrame containing the variable labels.
+        """
+        for year in self.years:
+            variables_key = '_'.join(
+                self.table_info['variables'].split('/')[5:])
+            variables_destination_path = f'{self.download_directory}/variables/{variables_key}__{year - 4}-{year}.json.tmp'
+
+            if not os.path.exists(variables_destination_path):
+                # download the variables file
+                url = self.table_info['variables'].format(year=year)
+                download_file_path = variables_destination_path.replace(
+                    '.json', '__raw.json')
+                Downloader(url, download_file_path).download()
+
+                # parse the variables file into a key-value pair
+                df = pandas.read_json(download_file_path)
+                df.columns = df.iloc[0]
+                df = df[1:]
+                df = df.set_index('name')
+                df.to_json(variables_destination_path,
+                           orient='index', indent=2)
+
+                # delete the unparsed file
+                os.remove(download_file_path)
+
+                print(
+                    f"Parsed variables file and saved to {variables_destination_path}")
+
+            # read the dataset variables file
+            all_variables: VariableLabels
+            with open(variables_destination_path, 'r') as file:
+                all_variables = json.load(file)
+
+            # read the variables in the downloaded data file
+            data_file_path = f'{self.table_folder_path}/{year - 4}-{year}.json'
+            keys: list[str] = []
+            with open(data_file_path, 'r') as file:
+                parsed: list[dict[str, str]] = json.load(file)
+                keys = list(parsed[0].keys())
+
+            # filter the variables to only include the ones in the table
+            data_variables = {
+                k: v['label'] for k, v in all_variables.items() if k in keys
+            }
+
+            # sort the variables by key such that the the order
+            # follows alphabetical order at each depth level
+            # (each depth level is separated by !!)
+            def sort_key(item):
+                value = item[1]
+                parts = value.split('!!')
+                return parts  # sort by each part of the string
+            sorted_data_variables = dict(
+                sorted(data_variables.items(), key=sort_key))
+
+            # write the filtered variables to a new file
+            filtered_variables_path = data_file_path.replace(
+                '.json', '.variables')
+            with open(filtered_variables_path, 'w') as file:
+                json.dump(sorted_data_variables, file, indent=2)
+
+    def to_time_series(self) -> Self:
+        """
+        Construct a time series file from the downloaded data.
+        The time series file is a JSON file that contains all the data for
+        the specified years in a single array.
+        The time series file is saved in the same directory as the downloaded
+        data files unless a path is specified.
+        The time series file is named time_series.json by default.
+        """
+        time_series_file_path = f'{self.table_folder_path}/time_series.json'
+
+        with open(time_series_file_path, 'w') as file:
+            # write the start of the array
+            file.write('[\n')
+
+            # read each year's data file and write it to the time series file
+            for year in self.years:
+                year_file_path = f'{self.table_folder_path}/{year - 4}-{year}.json'
+                with open(year_file_path, 'r') as year_file:
+                    # read the year file and write it to the time series file
+                    data = json.load(year_file)
+                    for row in data:
+                        # add the year to each row
+                        row['YEAR'] = f'{year - 4}-{year}'
+
+                        # write the row to the time series file
+                        json_string = json.dumps(row, sort_keys=True, indent=2)
+                        indented_json_strings = [
+                            '  ' + line for line in json_string.splitlines()]
+                        indented_json_string = '\n'.join(indented_json_strings)
+                        file.write(indented_json_string)
+
+                        # separate the objects with a comma
+                        # unless it is the last object in the file
+                        if row == data[-1] and year == self.years[-1]:
+                            file.write('\n')
+                        else:
+                            file.write(',\n')
+
+            # write the end of the array
+            file.write(']\n')
+
+        print(f"Time series data written to {time_series_file_path}")
+        return self
+
+    def prune_tables(self) -> Self:
+        """
+        Remove columns except the ones specified in the table info.
+        """
+
+        if tables[self.table]['columns'] is None:
+            print(f"Table {self.table} has no columns to prune.")
+            return self
+
+        for year in self.years:
+            dataset_file_path = f'{self.table_folder_path}/{year - 4}-{year}.json'
+            df = pandas.read_json(dataset_file_path, dtype=False)
+
+            # drop columns not in the table info
+            columns_to_keep = [name for name,
+                               alias in self.table_info['columns']] + ['NAME', 'ucgid']
+            df = df[columns_to_keep]
+
+            # calculate the GEOID
+            if 'GEOID' not in df.columns:
+                df['GEOID'] = df.apply(calculate_geoid, axis=1)
+
+            # rename columns to match the alias in the table info
+            df = df.rename(
+                columns={name: alias for name,
+                         alias in self.table_info['columns']}
+            )
+
+            df.to_json(dataset_file_path, orient='records', indent=2,)
+            print(
+                f"Pruned {dataset_file_path}")
+
+        return self
+
+
+def convert_census_lenght1_2d_array_to_object_array(filepath: str) -> None:
+    """
+    Converts the Census API's two dimensional JSON arrays into a more
+    standard array of objects.
+
+    **DANGER: This function accepts a file path and directly modifies it.**
+    """
+
+    # read the json with pandas
+    df = pandas.read_json(filepath, dtype=False)  # do not convert strings
+
+    # tell pandas that the first row is actually the header row
+    df.columns = df.iloc[0]
+    df = df[1:]
+
+    # ensure the numeric columns are converted to numeric types
+    df = convert_string_columns_to_numeric(df)
+
+    # overwrite the file with the new json
+    df.to_json(filepath, orient='records', indent=2)
+
+
+def calculate_geoid(row: dict[str, str]) -> None | str:
+    """
+    Calculate the GEOID from the ucgid field.
+    """
+    ucgid = row['ucgid']
+
+    if 'US' not in ucgid:
+        return None
+
+    # census tracts
+    if ucgid.startswith('1400000US'):
+        return 'T' + ucgid.split('US')[1]
+
+    return None

--- a/data-pipeline/src/main.py
+++ b/data-pipeline/src/main.py
@@ -1,7 +1,11 @@
 import os
 import sys
 
+from dotenv import load_dotenv
+
 from etl.runner import etl_runner
+
+load_dotenv()  # ensure .env file is loaded
 
 if __name__ == "__main__":
     # prompt whether to run the data pipeline


### PR DESCRIPTION
Downloads and processes 'Age and Sex', 'ACS Demographic and Housing Estimates', 'Educational Attainment', and 'Household Size by Vehicles Available'.

Example output:
```json
{
    "GEOID": "T45045000100",
    "NAME": "Census Tract 1, Greenville County, South Carolina",
    "YEAR": "2015-2019",
    "educational_attainment__associate_degree": 70,
    "educational_attainment__bachelor_degree": 377,
    "educational_attainment__graduate_or_professional_degree": 324,
    "educational_attainment__high_school_graduate_or_equivalent": 376,
    "educational_attainment__no_high_school": 71,
    "educational_attainment__some_college": 250,
    "educational_attainment__some_high_school": 355,
    "households__1_vehicle": 341,
    "households__2_vehicles": 211,
    "households__3_vehicles": 49,
    "households__4_plus_vehicles": 21,
    "households__no_vehicle": 72,
    "households__total": 694,
    "population__total": 2447,
    "race_ethnicity__asian_alone": 62,
    "race_ethnicity__black_alone": 531,
    "race_ethnicity__hispanic": 99,
    "race_ethnicity__multiple": 31,
    "race_ethnicity__native_alone": 0,
    "race_ethnicity__other_alone": 0,
    "race_ethnicity__pacific_islander_alone": 0,
    "race_ethnicity__white_alone": 1724,
    "ucgid": "1400000US45045000100"
  }
```