### PR TITLE
feat(frontend): add `<Section />` and `<SectionEntry />` components

### DIFF
--- a/frontend/src/components/common/Section/Section.tsx
+++ b/frontend/src/components/common/Section/Section.tsx
@@ -1,0 +1,60 @@
+import styled from '@emotion/styled';
+import type { JSX } from 'react';
+
+interface SectionProps {
+  /** The label for the section, which appears above the children's grid area */
+  title: string;
+  /** The heading level to use for the title. Defaults to 2 (h2). */
+  level?: number;
+  /**
+   * The children to render inside the section.
+   *
+   * Children are placed into a grid layout that adapts based on the width of the section.
+   * Smaller widths will show fewer columns, while larger widths will show more.
+   *
+   * **Use `SectionEntry` components for individual entries within the section.**
+   */
+  children: React.ReactNode;
+}
+
+export function Section(props: SectionProps) {
+  const TitleTag = `h${props.level || 2}` as keyof JSX.IntrinsicElements;
+
+  return (
+    <SectionComponent>
+      <TitleTag className="section-title">{props.title}</TitleTag>
+      <div className="section-content">{props.children}</div>
+    </SectionComponent>
+  );
+}
+
+const SectionComponent = styled.section`
+  container-type: inline-size;
+  container-name: section;
+
+  .section-content {
+    display: grid;
+    grid-template-columns: [left] repeat(4, 1fr) [right];
+    grid-auto-rows: minmax(3rem, min-content);
+    grid-auto-flow: dense;
+
+    @container section (max-width: 899px) {
+      grid-template-columns: [left] repeat(3, 1fr) [right];
+    }
+
+    @container section (max-width: 599px) {
+      grid-template-columns: [left] repeat(2, 1fr) [right];
+    }
+  }
+
+  .section-title {
+    grid-column: 1 / -1;
+    grid-row: 1;
+    font-size: 1rem;
+    font-weight: 600;
+    margin-bottom: 0.5rem;
+    color: var(--color-text-primary);
+    text-align: left;
+    line-height: 1.2;
+  }
+`;

--- a/frontend/src/components/common/Section/SectionEntry.tsx
+++ b/frontend/src/components/common/Section/SectionEntry.tsx
@@ -1,0 +1,91 @@
+import styled from '@emotion/styled';
+
+interface SectionEntryProps {
+  /** The component or element to be rendered inside this entry */
+  children: React.ReactElement;
+  /** Whether this section entry will be hidden from the section. Hiding an entry may cause other entries to be repositioned. */
+  hidden?: boolean;
+  /** Placement instructions, to be used when the section has a large width. */
+  l?: SectionEntryPlacement;
+  /** Placement instructions, to be used when the section has a medium width. */
+  m?: SectionEntryPlacement;
+  /** Placement instructions, to be used when the section has a small width. */
+  s?: SectionEntryPlacement;
+  /** Placement instructions, to be used when the large, medium, or small instructions do not apply. */
+  f?: SectionEntryPlacement;
+}
+
+interface SectionEntryPlacement {
+  /**
+   * The column placement of this entry in the section grid.
+   * This can be an valid CSS grid-column value.
+   *
+   * To span multiple columns with auto-placement, use a value like "span 2" or "span 3".
+   * To span specific columns, use a value like "2 / 4" or "1 / 4.
+   *
+   * @default "auto"
+   */
+  gridColumn?: string;
+
+  /**
+   * The row placement of this entry in the section grid.
+   * This can be an valid CSS grid-row value.
+   *
+   * To span multiple rows with auto-placement, use a value like "span 2" or "span 3".
+   * To span specific rows, use a value like "2 / 4" or "1 / 4".
+   *
+   * @default "auto"
+   */
+  gridRow?: string;
+}
+
+/**
+ * Represents a single entry in a section.
+ * This component is designed to be used as a direct child of a `Section` component.
+ * It allows for responsive placement of content within a section grid.
+ */
+export function SectionEntry(props: SectionEntryProps) {
+  if (props.hidden) {
+    return null;
+  }
+
+  const placementStrings = `
+    --grid-column--small: ${props.s?.gridColumn || props.f?.gridColumn || 'auto'};
+    --grid-row--small: ${props.s?.gridRow || props.f?.gridRow || 'auto'};
+    --grid-column--medium: ${props.m?.gridColumn || props.f?.gridColumn || 'auto'};
+    --grid-row--medium: ${props.m?.gridRow || props.f?.gridRow || 'auto'};
+    --grid-column--large: ${props.l?.gridColumn || props.f?.gridColumn || 'auto'};
+    --grid-row--large: ${props.l?.gridRow || props.f?.gridRow || 'auto'};
+  `;
+
+  return (
+    <SectionEntryComponent placementStrings={placementStrings}>
+      {props.children}
+    </SectionEntryComponent>
+  );
+}
+
+const SectionEntryComponent = styled.div<{ placementStrings: string }>`
+  overflow: auto;
+  position: relative;
+
+  ${(props) => props.placementStrings}
+
+  > * {
+    inline-size: 100%;
+    block-size: 100%;
+  }
+
+  grid-column: var(--grid-column--small);
+  grid-row: var(--grid-row--small);
+
+  @container section (min-width: 600px) {
+    grid-column: var(--grid-column--medium);
+    grid-row: var(--grid-row--medium);
+  }
+
+  @container section (min-width: 900px) {
+    grid-column: var(--grid-column--large);
+    grid-row: var(--grid-row--large);
+  }
+`;

--- a/frontend/src/components/common/index.ts
+++ b/frontend/src/components/common/index.ts
@@ -1,4 +1,6 @@
 export { Button } from './Button/Button';
 export { IconButton } from './IconButton/IconButton';
+export { Section } from './Section/Section';
+export { SectionEntry } from './Section/SectionEntry';
 export { Tab } from './Tabs/Tab';
 export { Tabs } from './Tabs/Tabs';

--- a/frontend/src/views/DevModeComponentsAll.tsx
+++ b/frontend/src/views/DevModeComponentsAll.tsx
@@ -1,4 +1,4 @@
-import { Button, IconButton, Tab, Tabs } from '../components';
+import { Button, IconButton, Section, SectionEntry, Tab, Tabs } from '../components';
 
 export function DevModeComponentsAll() {
   return (
@@ -56,7 +56,7 @@ export function DevModeComponentsAll() {
       </Tabs>
 
       <h2>Button</h2>
-      <div style={{ padding: 20, display: 'flex', gap: '0.5rem' }}>
+      <div style={{ padding: 20, display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
         <Button
           href="https://www.google.com/"
           onClick={() => {
@@ -130,6 +130,59 @@ export function DevModeComponentsAll() {
             />
           </svg>
         </IconButton>
+      </div>
+
+      <h2>Section</h2>
+      <div style={{ display: 'flex', flexDirection: 'row', gap: '1rem' }}>
+        <Section title="Section Title">
+          <SectionEntry>
+            <div>Card 1</div>
+          </SectionEntry>
+          <SectionEntry>
+            <div>Card 2</div>
+          </SectionEntry>
+          <SectionEntry f={{ gridColumn: 'span 2' }}>
+            <div>Card 3</div>
+          </SectionEntry>
+          <SectionEntry>
+            <div>Card 4</div>
+          </SectionEntry>
+          <SectionEntry>
+            <div>Card 5</div>
+          </SectionEntry>
+          <SectionEntry>
+            <div>Card 6</div>
+          </SectionEntry>
+          <SectionEntry>
+            <div>Card 7</div>
+          </SectionEntry>
+          <SectionEntry m={{ gridColumn: '2 / 4', gridRow: '1 / 3' }}>
+            <div>Card 8</div>
+          </SectionEntry>
+        </Section>
+        <Section title="Section Title 2">
+          <SectionEntry hidden>
+            <div>Card 1</div>
+          </SectionEntry>
+          <SectionEntry hidden>
+            <div>Card 2</div>
+          </SectionEntry>
+          <SectionEntry f={{ gridColumn: 'span 2' }}>
+            <div>Card 3</div>
+          </SectionEntry>
+          <SectionEntry>
+            <div>Card 4</div>
+          </SectionEntry>
+          <SectionEntry>
+            <div>Card 5</div>
+          </SectionEntry>
+          <SectionEntry>
+            <div>Card 6</div>
+          </SectionEntry>
+          <SectionEntry>
+            <div>Card 7</div>
+          </SectionEntry>
+        </Section>
       </div>
     </div>
   );


### PR DESCRIPTION
This PR adds adaptable components for rendering sections. Each section cans 2-4 columns, adjusted based on the section width.

The section should have `<SectionEntry />` children. These children can be hidden. They can also be set to span multiple columns and rows, which different settings available for small-, medium-, and large-width sections.