### PR TITLE
feat(frontend): add views for each tab of the dashboard

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -12,9 +12,11 @@
     />
     <style>
       html,
-      body {
+      body,
+      #gcmd-root {
         margin: 0;
         padding: 0;
+        height: 100%;
       }
     </style>
   </head>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,23 +1,64 @@
 import styled from '@emotion/styled';
 import { Route, Routes } from 'react-router';
-import { DevModeComponentsAll } from './views';
+import { CoreFrameContext, createCoreFrameContextValue } from './components';
+import {
+  COMPONENTS_ROUTE_FRAGMENT,
+  TAB_2_FRAGMENT,
+  TAB_3_FRAGMENT,
+  TAB_4_FRAGMENT,
+  TAB_5_FRAGMENT,
+} from './components/navigation';
+import {
+  DevModeComponentsAll,
+  EssentialServicesAccess,
+  FutureOpportunities,
+  GeneralAccess,
+  JobAccess,
+  RoadsVsTransit,
+} from './views';
 
 export default function App() {
   return (
-    <>
-      {import.meta.env.DEV ? <PlaceholderGreenvilleConnectsWebsiteHeader /> : null}
-      <Routes>
-        <Route path="/" element={<h1>Greenville Connects Mobility Dashboard</h1>} />
-        {import.meta.env.DEV ? (
-          <Route path="/components" element={<DevModeComponentsAll />} />
-        ) : null}
-      </Routes>
-    </>
+    <AppWrapper>
+      <CoreFrameContext value={createCoreFrameContextValue()}>
+        {import.meta.env.DEV ? <PlaceholderGreenvilleConnectsWebsiteHeader /> : null}
+
+        <Routes>
+          <Route index Component={GeneralAccess} />
+          <Route path={TAB_2_FRAGMENT} Component={FutureOpportunities} />
+          <Route path={TAB_3_FRAGMENT} Component={JobAccess} />
+          <Route path={TAB_4_FRAGMENT} Component={EssentialServicesAccess} />
+          <Route path={TAB_5_FRAGMENT} Component={RoadsVsTransit} />
+
+          {import.meta.env.DEV ? (
+            <Route path={COMPONENTS_ROUTE_FRAGMENT} element={<DevModeComponentsAll />} />
+          ) : null}
+        </Routes>
+      </CoreFrameContext>
+    </AppWrapper>
   );
 }
+
+const AppWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  inline-size: 100%;
+  block-size: 100%;
+  overflow: hidden;
+  box-sizing: border-box;
+
+  max-height: 100vh;
+  overflow: auto;
+
+  > div:last-of-type {
+    flex-grow: 1;
+  }
+`;
 
 const PlaceholderGreenvilleConnectsWebsiteHeader = styled.div`
   block-size: 4rem;
   inline-size: 100%;
   background-color: var(--color-green2);
+  flex-grow: 0;
+  flex-shrink: 0;
 `;

--- a/frontend/src/components/layout/CoreFrame/CoreFrame.tsx
+++ b/frontend/src/components/layout/CoreFrame/CoreFrame.tsx
@@ -1,7 +1,8 @@
 import styled from '@emotion/styled';
-import { useRef, useState } from 'react';
+import { useContext, useRef, useState } from 'react';
 import { useRect } from '../../../hooks';
 import { Tab } from '../../common';
+import { CoreFrameContext } from './CoreFrameContext';
 import { SidebarWrapper } from './SidebarWrapper';
 
 interface CoreFrameProps {
@@ -26,7 +27,7 @@ export function CoreFrame(props: CoreFrameProps) {
 
   const [activeMobileSection, setActiveMobileSection] = useState(0);
 
-  const [fixedSidebarOpen, setFixedSidebarOpen] = useState(true);
+  const { fixedSidebarOpen } = useContext(CoreFrameContext);
 
   return (
     <Container ref={containerRef}>
@@ -66,12 +67,7 @@ export function CoreFrame(props: CoreFrameProps) {
               <MainArea>{props.sections?.map((section) => section)}</MainArea>
             </>
           )}
-          <SidebarWrapper
-            frameWidth={width}
-            onToggleFixedSidebar={(forcedClosed) => setFixedSidebarOpen(!forcedClosed)}
-          >
-            {props.sidebar}
-          </SidebarWrapper>
+          <SidebarWrapper frameWidth={width}>{props.sidebar}</SidebarWrapper>
         </InnerFrame>
       </OuterFrame>
     </Container>

--- a/frontend/src/components/layout/CoreFrame/CoreFrameContext.ts
+++ b/frontend/src/components/layout/CoreFrame/CoreFrameContext.ts
@@ -1,0 +1,70 @@
+import { createContext, useCallback, useState } from 'react';
+
+export interface CoreFrameContextValue {
+  optionsOpen: boolean;
+  scrimVisible: boolean;
+  showButtonVisible: boolean;
+  forceClosed: boolean;
+  fixedSidebarOpen: boolean;
+  setOptionsOpen: (open: boolean) => void;
+  setForceClosed: (forceClosed: boolean) => void;
+}
+
+export function createCoreFrameContextValue(): CoreFrameContextValue {
+  // sidebar-related state
+  const [optionsOpen, _setOptionsOpen] = useState(false);
+  const setOptionsOpen = useCallback((bool: boolean) => {
+    _setOptionsOpen(bool);
+    setForceClosed(false, false);
+    setScrimVisible(bool);
+    setShowButtonVisible(!bool);
+  }, []);
+
+  const [scrimVisible, _setScrimVisible] = useState(false);
+  const setScrimVisible = useCallback((bool: boolean) => {
+    if (bool) {
+      _setScrimVisible(true);
+    } else {
+      setTimeout(() => {
+        _setScrimVisible(false);
+      }, 300);
+    }
+  }, []);
+
+  const [showButtonVisible, _setShowButtonVisible] = useState(true);
+  const setShowButtonVisible = useCallback((bool: boolean) => {
+    if (bool) {
+      setTimeout(() => {
+        _setShowButtonVisible(true);
+      }, 120);
+    } else {
+      _setShowButtonVisible(false);
+    }
+  }, []);
+
+  const [forceClosed, _setForceClosed] = useState(false);
+  const setForceClosed = useCallback(
+    (bool: boolean, controlShowButton = true) => {
+      _setForceClosed(bool);
+      setFixedSidebarOpen(!bool);
+      if (controlShowButton) {
+        setShowButtonVisible(bool);
+      }
+    },
+    [_setForceClosed]
+  );
+
+  const [fixedSidebarOpen, setFixedSidebarOpen] = useState(true);
+
+  return {
+    optionsOpen,
+    scrimVisible,
+    showButtonVisible,
+    forceClosed,
+    setOptionsOpen,
+    setForceClosed,
+    fixedSidebarOpen,
+  };
+}
+
+export const CoreFrameContext = createContext<CoreFrameContextValue>({} as CoreFrameContextValue);

--- a/frontend/src/components/layout/CoreFrame/SidebarWrapper.tsx
+++ b/frontend/src/components/layout/CoreFrame/SidebarWrapper.tsx
@@ -1,38 +1,22 @@
 import styled from '@emotion/styled';
-import { useCallback, useEffect, useState } from 'react';
+import { useContext, useEffect } from 'react';
 import { Button, IconButton } from '../../common';
+import { CoreFrameContext } from './CoreFrameContext';
 
 interface SidebarWrapperProps {
   children: React.ReactNode;
   frameWidth: number;
-  onToggleFixedSidebar?: (open: boolean) => void;
 }
 
 export function SidebarWrapper(props: SidebarWrapperProps) {
-  const [optionsOpen, _setOptionsOpen] = useState(false);
-  const setOptionsOpen = useCallback((bool: boolean) => {
-    _setOptionsOpen(bool);
-    setForceClosed(false);
-
-    if (bool) {
-      setScrimVisible(true);
-    } else {
-      setTimeout(() => {
-        setScrimVisible(false);
-      }, 300);
-    }
-  }, []);
-
-  const [scrimVisible, setScrimVisible] = useState(false);
-
-  const [forceClosed, _setForceClosed] = useState(false);
-  const setForceClosed = useCallback(
-    (bool: boolean) => {
-      _setForceClosed(bool);
-      props.onToggleFixedSidebar?.(bool);
-    },
-    [props.onToggleFixedSidebar]
-  );
+  const {
+    optionsOpen,
+    setOptionsOpen,
+    scrimVisible,
+    showButtonVisible,
+    forceClosed,
+    setForceClosed,
+  } = useContext(CoreFrameContext);
 
   // close the overlay sidebar if the window expands to >= 1280px
   useEffect(() => {
@@ -64,7 +48,7 @@ export function SidebarWrapper(props: SidebarWrapperProps) {
   }
 
   const openButton = (
-    <OpenButtonWrapper visible={scrimVisible}>
+    <OpenButtonWrapper visible={showButtonVisible}>
       <Button
         onClick={() => (props.frameWidth >= 1280 ? setForceClosed(false) : setOptionsOpen(true))}
         iconLeft={
@@ -172,7 +156,7 @@ const OpenButtonWrapper = styled.div<{ visible: boolean }>`
   transition: transform 200ms cubic-bezier(0.16, 1, 0.3, 1);
 
   @container core (min-width: 900px) {
-    transform: ${({ visible }) => (visible ? 'translateX(100%)' : 'translateX(0)')};
+    transform: ${({ visible }) => (visible ? 'translateX(0)' : 'translateX(100%)')};
 
     button {
       border-radius: var(--button-radius) 0 0 var(--button-radius);
@@ -181,7 +165,7 @@ const OpenButtonWrapper = styled.div<{ visible: boolean }>`
   }
 
   @container core (max-width: 899px) {
-    transform: rotate(90deg) ${({ visible }) => (visible ? 'translateY(-100%)' : 'translateY(0)')};
+    transform: rotate(90deg) ${({ visible }) => (visible ? 'translateY(0)' : 'translateY(-100%)')};
     transform-origin: top right;
     bottom: 3rem;
 

--- a/frontend/src/components/layout/index.ts
+++ b/frontend/src/components/layout/index.ts
@@ -1,1 +1,6 @@
 export { CoreFrame } from './CoreFrame/CoreFrame';
+export {
+  CoreFrameContext,
+  createCoreFrameContextValue,
+  type CoreFrameContextValue,
+} from './CoreFrame/CoreFrameContext';

--- a/frontend/src/components/navigation/AppNavigation.tsx
+++ b/frontend/src/components/navigation/AppNavigation.tsx
@@ -1,0 +1,55 @@
+import { useLocation, useNavigate } from 'react-router';
+import { Tab, Tabs } from '../common';
+import {
+  TAB_1_FRAGMENT,
+  TAB_2_FRAGMENT,
+  TAB_3_FRAGMENT,
+  TAB_4_FRAGMENT,
+  TAB_5_FRAGMENT,
+} from './constants';
+
+export function AppNavigation() {
+  const { pathname } = useLocation();
+  const navigate = useNavigate();
+
+  const handleClick =
+    (to: string) => (evt: React.MouseEvent<HTMLAnchorElement | HTMLButtonElement, MouseEvent>) => {
+      evt.preventDefault();
+      navigate(to);
+    };
+
+  return (
+    <Tabs>
+      <Tab
+        label="General Access"
+        href={'#' + TAB_1_FRAGMENT}
+        isActive={pathname === TAB_1_FRAGMENT}
+        onClick={handleClick(TAB_1_FRAGMENT)}
+      />
+      <Tab
+        label="Future Opportunities"
+        href={'#' + TAB_2_FRAGMENT}
+        isActive={pathname === TAB_2_FRAGMENT}
+        onClick={handleClick(TAB_2_FRAGMENT)}
+      />
+      <Tab
+        label="Job Access"
+        href={'#' + TAB_3_FRAGMENT}
+        isActive={pathname === TAB_3_FRAGMENT}
+        onClick={handleClick(TAB_3_FRAGMENT)}
+      />
+      <Tab
+        label="Access to Essential Services"
+        href={'#' + TAB_4_FRAGMENT}
+        isActive={pathname === TAB_4_FRAGMENT}
+        onClick={handleClick(TAB_4_FRAGMENT)}
+      />
+      <Tab
+        label="Roads or Transit?"
+        href={'#' + TAB_5_FRAGMENT}
+        isActive={pathname === TAB_5_FRAGMENT}
+        onClick={handleClick(TAB_5_FRAGMENT)}
+      />
+    </Tabs>
+  );
+}

--- a/frontend/src/components/navigation/constants.ts
+++ b/frontend/src/components/navigation/constants.ts
@@ -1,0 +1,6 @@
+export const TAB_1_FRAGMENT = '/';
+export const TAB_2_FRAGMENT = '/future';
+export const TAB_3_FRAGMENT = '/job-access';
+export const TAB_4_FRAGMENT = '/services-access';
+export const TAB_5_FRAGMENT = '/roads';
+export const COMPONENTS_ROUTE_FRAGMENT = '/components';

--- a/frontend/src/components/navigation/index.ts
+++ b/frontend/src/components/navigation/index.ts
@@ -1,0 +1,2 @@
+export { AppNavigation } from './AppNavigation';
+export * from './constants';

--- a/frontend/src/views/EssentialServicesAccess.tsx
+++ b/frontend/src/views/EssentialServicesAccess.tsx
@@ -1,0 +1,6 @@
+import { CoreFrame } from '../components';
+import { AppNavigation } from '../components/navigation';
+
+export function EssentialServicesAccess() {
+  return <CoreFrame outerStyle={{ height: '100%' }} header={<AppNavigation />} />;
+}

--- a/frontend/src/views/FutureOpportunities.tsx
+++ b/frontend/src/views/FutureOpportunities.tsx
@@ -1,0 +1,6 @@
+import { CoreFrame } from '../components';
+import { AppNavigation } from '../components/navigation';
+
+export function FutureOpportunities() {
+  return <CoreFrame outerStyle={{ height: '100%' }} header={<AppNavigation />} />;
+}

--- a/frontend/src/views/GeneralAccess.tsx
+++ b/frontend/src/views/GeneralAccess.tsx
@@ -1,0 +1,6 @@
+import { CoreFrame } from '../components';
+import { AppNavigation } from '../components/navigation';
+
+export function GeneralAccess() {
+  return <CoreFrame outerStyle={{ height: '100%' }} header={<AppNavigation />} />;
+}

--- a/frontend/src/views/JobAccess.tsx
+++ b/frontend/src/views/JobAccess.tsx
@@ -1,0 +1,6 @@
+import { CoreFrame } from '../components';
+import { AppNavigation } from '../components/navigation';
+
+export function JobAccess() {
+  return <CoreFrame outerStyle={{ height: '100%' }} header={<AppNavigation />} />;
+}

--- a/frontend/src/views/RoadsVsTransit.tsx
+++ b/frontend/src/views/RoadsVsTransit.tsx
@@ -1,0 +1,6 @@
+import { CoreFrame } from '../components';
+import { AppNavigation } from '../components/navigation';
+
+export function RoadsVsTransit() {
+  return <CoreFrame outerStyle={{ height: '100%' }} header={<AppNavigation />} />;
+}

--- a/frontend/src/views/index.ts
+++ b/frontend/src/views/index.ts
@@ -1,1 +1,6 @@
 export { DevModeComponentsAll } from './DevModeComponentsAll';
+export { EssentialServicesAccess } from './EssentialServicesAccess';
+export { FutureOpportunities } from './FutureOpportunities';
+export { GeneralAccess } from './GeneralAccess';
+export { JobAccess } from './JobAccess';
+export { RoadsVsTransit } from './RoadsVsTransit';


### PR DESCRIPTION
This PR adds a view for each tab of the dashboard. Views are located in the frontend/src/views folder.

Each view is initialized with an empty `CoreFrame` component. Each also includes the `AppNavigation` component, which provides the tabs for the dashboard.