### PR TITLE
feat(frontend): add `useAppData` hook and `AppDataContext`, which provide a mechanism for globally loading data originating from data-pipeline) and consuming it via `useAppData`.

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
-import { Route, Routes } from 'react-router';
+import { useMemo } from 'react';
+import { Route, Routes, useSearchParams } from 'react-router';
 import { CoreFrameContext, createCoreFrameContextValue } from './components';
 import {
   COMPONENTS_ROUTE_FRAGMENT,
@@ -8,6 +9,7 @@ import {
   TAB_4_FRAGMENT,
   TAB_5_FRAGMENT,
 } from './components/navigation';
+import { AppDataContext, createAppDataContext } from './hooks/useAppData';
 import {
   DevModeComponentsAll,
   EssentialServicesAccess,
@@ -18,23 +20,53 @@ import {
 } from './views';
 
 export default function App() {
+  const [searchParams] = useSearchParams();
+
+  const areas = useMemo(
+    () =>
+      searchParams
+        .get('areas')
+        ?.split(',')
+        .map((str) => str.trim()) ?? [],
+    [searchParams]
+  );
+  const seasons = useMemo(
+    () =>
+      (searchParams.get('seasons')?.split(',') || [])
+        .map((str) => {
+          return str
+            .trim()
+            .split(':')
+            .map((v) => v.trim());
+        })
+        .map(([quarter, year]) => [quarter, parseInt(year)] as const)
+        .filter((v): v is ['Q2' | 'Q4', number] => {
+          const quarter = v[0];
+          const year = v[1];
+          return ['Q2', 'Q4'].includes(quarter) && year >= 2019;
+        }) satisfies Parameters<typeof createAppDataContext>['1'],
+    [searchParams]
+  );
+
   return (
     <AppWrapper>
-      <CoreFrameContext value={createCoreFrameContextValue()}>
-        {import.meta.env.DEV ? <PlaceholderGreenvilleConnectsWebsiteHeader /> : null}
+      <AppDataContext value={createAppDataContext(areas, seasons)}>
+        <CoreFrameContext value={createCoreFrameContextValue()}>
+          {import.meta.env.DEV ? <PlaceholderGreenvilleConnectsWebsiteHeader /> : null}
 
-        <Routes>
-          <Route index Component={GeneralAccess} />
-          <Route path={TAB_2_FRAGMENT} Component={FutureOpportunities} />
-          <Route path={TAB_3_FRAGMENT} Component={JobAccess} />
-          <Route path={TAB_4_FRAGMENT} Component={EssentialServicesAccess} />
-          <Route path={TAB_5_FRAGMENT} Component={RoadsVsTransit} />
+          <Routes>
+            <Route index Component={GeneralAccess} />
+            <Route path={TAB_2_FRAGMENT} Component={FutureOpportunities} />
+            <Route path={TAB_3_FRAGMENT} Component={JobAccess} />
+            <Route path={TAB_4_FRAGMENT} Component={EssentialServicesAccess} />
+            <Route path={TAB_5_FRAGMENT} Component={RoadsVsTransit} />
 
-          {import.meta.env.DEV ? (
-            <Route path={COMPONENTS_ROUTE_FRAGMENT} element={<DevModeComponentsAll />} />
-          ) : null}
-        </Routes>
-      </CoreFrameContext>
+            {import.meta.env.DEV ? (
+              <Route path={COMPONENTS_ROUTE_FRAGMENT} element={<DevModeComponentsAll />} />
+            ) : null}
+          </Routes>
+        </CoreFrameContext>
+      </AppDataContext>
     </AppWrapper>
   );
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -50,8 +50,8 @@ export default function App() {
 
   return (
     <AppWrapper>
-      <AppDataContext value={createAppDataContext(areas, seasons)}>
-        <CoreFrameContext value={createCoreFrameContextValue()}>
+      <AppDataContext.Provider value={createAppDataContext(areas, seasons)}>
+        <CoreFrameContext.Provider value={createCoreFrameContextValue()}>
           {import.meta.env.DEV ? <PlaceholderGreenvilleConnectsWebsiteHeader /> : null}
 
           <Routes>
@@ -65,8 +65,8 @@ export default function App() {
               <Route path={COMPONENTS_ROUTE_FRAGMENT} element={<DevModeComponentsAll />} />
             ) : null}
           </Routes>
-        </CoreFrameContext>
-      </AppDataContext>
+        </CoreFrameContext.Provider>
+      </AppDataContext.Provider>
     </AppWrapper>
   );
 }

--- a/frontend/src/components/navigation/AppNavigation.tsx
+++ b/frontend/src/components/navigation/AppNavigation.tsx
@@ -9,7 +9,7 @@ import {
 } from './constants';
 
 export function AppNavigation() {
-  const { pathname } = useLocation();
+  const { pathname, search } = useLocation();
   const navigate = useNavigate();
 
   const handleClick =
@@ -22,33 +22,33 @@ export function AppNavigation() {
     <Tabs>
       <Tab
         label="General Access"
-        href={'#' + TAB_1_FRAGMENT}
+        href={'#' + TAB_1_FRAGMENT + search}
         isActive={pathname === TAB_1_FRAGMENT}
-        onClick={handleClick(TAB_1_FRAGMENT)}
+        onClick={handleClick(TAB_1_FRAGMENT + search)}
       />
       <Tab
         label="Future Opportunities"
-        href={'#' + TAB_2_FRAGMENT}
+        href={'#' + TAB_2_FRAGMENT + search}
         isActive={pathname === TAB_2_FRAGMENT}
-        onClick={handleClick(TAB_2_FRAGMENT)}
+        onClick={handleClick(TAB_2_FRAGMENT + search)}
       />
       <Tab
         label="Job Access"
-        href={'#' + TAB_3_FRAGMENT}
+        href={'#' + TAB_3_FRAGMENT + search}
         isActive={pathname === TAB_3_FRAGMENT}
-        onClick={handleClick(TAB_3_FRAGMENT)}
+        onClick={handleClick(TAB_3_FRAGMENT + search)}
       />
       <Tab
         label="Access to Essential Services"
-        href={'#' + TAB_4_FRAGMENT}
+        href={'#' + TAB_4_FRAGMENT + search}
         isActive={pathname === TAB_4_FRAGMENT}
-        onClick={handleClick(TAB_4_FRAGMENT)}
+        onClick={handleClick(TAB_4_FRAGMENT + search)}
       />
       <Tab
         label="Roads or Transit?"
-        href={'#' + TAB_5_FRAGMENT}
+        href={'#' + TAB_5_FRAGMENT + search}
         isActive={pathname === TAB_5_FRAGMENT}
-        onClick={handleClick(TAB_5_FRAGMENT)}
+        onClick={handleClick(TAB_5_FRAGMENT + search)}
       />
     </Tabs>
   );

--- a/frontend/src/data.d.ts
+++ b/frontend/src/data.d.ts
@@ -1,0 +1,126 @@
+type CensusHouseholdsTimeSeries = CensusHouseholdsValue[];
+type CensusRaceEthnicityTimeSeries = CensusRaceEthnicityValue[];
+type CensusPopulationTotalTimeSeries = CensusPopulationTotalValue[];
+type CensusEducationalAttainmentTimeSeries = CensusEducationalAttainmentValue[];
+type ReplicaNetworkSegments = ReplicaNetworkSegment[];
+type ReplicaSyntheticPeople = ReplicaSyntheticPerson[];
+type ReplicaTrips = ReplicaTrip[];
+
+interface CoreCensusValue {
+  NAME: string;
+  ucgid: string;
+  GEOID: string;
+}
+
+interface CensusHouseholdsValue extends CoreCensusValue {
+  households__total: number;
+  households__no_vehicle: number;
+  households__1_vehicle: number;
+  households__2_vehicles: number;
+  households__3_vehicles: number;
+  households__4_plus_vehicles: number;
+}
+
+interface CensusRaceEthnicityValue extends CoreCensusValue {
+  race_ethnicity__white_alone: number;
+  race_ethnicity__black_alone: number;
+  race_ethnicity__native_alone: number;
+  race_ethnicity__asian_alone: number;
+  race_ethnicity__pacific_islander_alone: number;
+  race_ethnicity__other_alone: number;
+  race_ethnicity__multiple: number;
+  race_ethnicity__hispanic: number;
+}
+
+interface CensusPopulationTotalValue extends CoreCensusValue {
+  population__total: number;
+}
+
+interface CensusEducationalAttainmentValue extends CoreCensusValue {
+  educational_attainment__no_high_school: number;
+  educational_attainment__some_high_school: number;
+  educational_attainment__high_school_graduate_or_equivalent: number;
+  educational_attainment__some_college: number;
+  educational_attainment__associate_degree: number;
+  educational_attainment__bachelor_degree: number;
+  educational_attainment__graduate_or_professional_degree: number;
+}
+
+type ArrayString = string;
+type LineString = string;
+
+interface ReplicaNetworkSegment {
+  stableEdgeId: string;
+  startLat: number;
+  startLon: number;
+  endLat: number;
+  endLon: number;
+  streetName: string;
+  distance: number;
+  osmid: string;
+  speed: number;
+  flags: ArrayString;
+  lanes: number;
+  highway: string;
+  geometry: LineString;
+}
+
+interface ReplicaSyntheticPerson {
+  household_id: string;
+  person_id: string;
+  BLOCKGROUP: string;
+  BLOCKGROUP_work: string;
+  BLOCKGROUP_school: any;
+  TRACT: string;
+  TRACT_work: string;
+  TRACT_school: any;
+  age_group: string;
+  age: number;
+  sex: string;
+  race: string;
+  ethnicity: string;
+  individual_income_group: string;
+  individual_income: number;
+  employment: string;
+  education: string;
+  school_grade_attending: string;
+  industry: string;
+  household_role: string;
+  subfamily_number: number;
+  subfamily_relationship: string;
+  commute_mode: string;
+  tenure: string;
+  migration: string;
+  household_size: string;
+  household_income_group: string;
+  household_income: number;
+  family_structure: string;
+  vehicles: string;
+  building_type: string;
+  resident_type: string;
+  language: string;
+  lat: number;
+  lng: number;
+  lat_work: number;
+  lng_work: number;
+  lat_school: any;
+  lng_school: any;
+  wfh: string;
+}
+
+interface ReplicaTrip {
+  household_id: string;
+  activity_id: string;
+  person_id: string;
+  mode: string;
+  travel_purpose: string;
+  tour_type: string;
+  transit_route_ids: string[];
+  network_link_ids: string[];
+  vehicle_type: any;
+  start_lng: number;
+  start_lat: number;
+  end_lng: number;
+  end_lat: number;
+  source_table: string;
+}

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -1,1 +1,2 @@
+export { _useAppDataContext as useAppData } from './useAppData';
 export { useRect } from './useRect';

--- a/frontend/src/hooks/useAppData.ts
+++ b/frontend/src/hooks/useAppData.ts
@@ -95,7 +95,7 @@ async function fetchData<T = Record<string, unknown>>(
   })
     .then((response) => {
       if (!response.ok) {
-        throw new Error('Network response was not ok');
+        throw new Error(`Network response was not ok. Status: ${response.status}, URL: ${response.url}`);
       }
       return response;
     })

--- a/frontend/src/hooks/useAppData.ts
+++ b/frontend/src/hooks/useAppData.ts
@@ -80,8 +80,6 @@ function _useAppData({ areas, seasons }: AppDataHookParameters) {
     return () => {
       console.log('Cleaning up fetch effect in useAppData');
       abortController.abort('fetch effect in useAppData is being cleaned up');
-      setLoading(false);
-      setErrors([new Error('Data fetch aborted')]);
     };
   }, [dataPromises]);
 

--- a/frontend/src/hooks/useAppData.ts
+++ b/frontend/src/hooks/useAppData.ts
@@ -1,0 +1,239 @@
+import { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import { inflateResponse } from '../utils';
+
+export function createAppDataContext(
+  areas: AppDataHookParameters['areas'],
+  seasons: AppDataHookParameters['seasons']
+) {
+  return _useAppData({ areas, seasons });
+}
+
+export type AppDataContextValue = ReturnType<typeof _useAppData>;
+export const AppDataContext = createContext<AppDataContextValue>({} as AppDataContextValue);
+
+export function _useAppDataContext() {
+  return useContext(AppDataContext);
+}
+
+interface AppDataHookParameters {
+  areas: string[];
+  seasons: ['Q2' | 'Q4', number][];
+}
+
+function _useAppData({ areas, seasons }: AppDataHookParameters) {
+  // fetch the census data, which is a static time series file for each category that
+  // applies to all areas and seasons
+  const censusPromises = useMemo(() => {
+    const censusData = getCensusData();
+    return {
+      households: () => censusData.households,
+      race_ethnicity: () => censusData.race_ethnicity,
+      population_total: () => censusData.population_total,
+      educational_attainment: () => censusData.educational_attainment,
+    };
+  }, []);
+
+  // merge the replica promises with the census promises
+  const dataPromises = useMemo(() => {
+    const replicaPaths = constructReplicaPaths(areas, seasons);
+    const replicaPromises = constructReplicaPromises(replicaPaths);
+    return replicaPromises.map((promises) => {
+      return {
+        ...promises,
+        ...censusPromises,
+      };
+    });
+  }, [areas, seasons]);
+
+  // manage the state of the fetch data, showing a loading state while the data is being fetched
+  const [data, setData] = useState<ResolvedData<(typeof dataPromises)[number]>[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [errors, setErrors] = useState<Error[] | null>(null);
+  useEffect(() => {
+    // set up an abort controller to cancel the fetch request if the component unmounts or the dependencies change
+    const abortController = new AbortController();
+    const { signal } = abortController;
+
+    if (loading === false) {
+      setLoading(true);
+      setErrors(null);
+      resolveArrayOfPromiseRecords(dataPromises, signal)
+        .then((fetchedData) => {
+          if (fetchedData) {
+            setData(fetchedData);
+          }
+        })
+        .catch((error) => {
+          if (!signal.aborted) {
+            setErrors((prevErrors) => (prevErrors ? [...prevErrors, error] : [error]));
+            console.error('An error occurred while fetching data. Please try again later.', error);
+          }
+          return null;
+        })
+        .finally(() => {
+          if (!signal.aborted) {
+            setLoading(false);
+          }
+        });
+    }
+
+    return () => {
+      console.log('Cleaning up fetch effect in useAppData');
+      abortController.abort('fetch effect in useAppData is being cleaned up');
+      setLoading(false);
+      setErrors([new Error('Data fetch aborted')]);
+    };
+  }, [dataPromises]);
+
+  return { data, loading, errors };
+}
+
+async function fetchData<T = Record<string, unknown>>(
+  input: RequestInfo | URL,
+  abortSignal?: AbortSignal
+): Promise<T> {
+  return fetch(input, {
+    signal: abortSignal,
+  })
+    .then((response) => {
+      if (!response.ok) {
+        throw new Error('Network response was not ok');
+      }
+      return response;
+    })
+    .then(inflateResponse)
+    .then((text) => {
+      return JSON.parse(text);
+    });
+}
+
+type DataPromises = Record<string, (abortSignal?: AbortSignal) => Promise<unknown>>[];
+
+type ResolvedData<T extends DataPromises[number]> = {
+  [K in keyof T]: Awaited<ReturnType<T[K]>>;
+};
+
+/**
+ * Resolve all promises from an input array of objects with promises as their values.
+ * @param dataPromises An array of objects, where each object property is a function that returns a promise.
+ * @param abortSignal A signal to abort the fetch requests. Generate one with `const abortController = new AbortController()` and provide `abortController.signal`. Abort with `abortController.abort()`.
+ * @returns An array of objects with the resolved values of the promises.
+ */
+async function resolveArrayOfPromiseRecords<T extends DataPromises>(
+  dataPromises: T,
+  abortSignal?: AbortSignal
+): Promise<ResolvedData<T[number]>[] | null> {
+  return Promise.all(
+    dataPromises.map(async (promises) => {
+      const results = await Promise.all(
+        Object.entries(promises).map(async ([key, fn]) => [key, await fn(abortSignal)] as const)
+      );
+
+      const data: Record<string, unknown> = {};
+      results.forEach(([key, result]) => {
+        if (promises.hasOwnProperty(key)) {
+          data[key] = result;
+        }
+      });
+      return data as ResolvedData<T[number]>;
+    })
+  );
+}
+
+function handleError(key: string) {
+  return (error: Error) => {
+    if (!error.message.includes('useAppData is being cleaned up')) {
+      // ignore errors that are caused by the cleanup of the useAppData effect
+      console.error(`Error fetching ${key} data:`, error);
+    }
+
+    throw new Error(
+      `Error fetching ${key} data: ` +
+        (error.message || error) +
+        `. See the console for more details.`
+    );
+  };
+}
+
+/**
+ * Fetches the core census data that is used across all areas and seasons.
+ */
+function getCensusData() {
+  const paths = {
+    households: `./data/census_acs_5year/B08201/time_series.json.deflate`,
+    race_ethnicity: `./data/census_acs_5year/DP05/time_series.json.deflate`,
+    population_total: `./data/census_acs_5year/S0101/time_series.json.deflate`,
+    educational_attainment: `./data/census_acs_5year/S1501/time_series.json.deflate`,
+  };
+
+  const households = fetchData<CensusHouseholdsTimeSeries>(paths.households).catch(
+    handleError('households')
+  );
+  const race_ethnicity = fetchData<CensusRaceEthnicityTimeSeries>(paths.race_ethnicity).catch(
+    handleError('race_ethnicity')
+  );
+  const population_total = fetchData<CensusPopulationTotalTimeSeries>(paths.population_total).catch(
+    handleError('population_total')
+  );
+  const educational_attainment = fetchData<CensusEducationalAttainmentTimeSeries>(
+    paths.educational_attainment
+  ).catch(handleError('educational_attainment'));
+
+  return { households, race_ethnicity, population_total, educational_attainment };
+}
+
+/**
+ * Constructs paths for the replica data based on the areas and seasons.
+ */
+function constructReplicaPaths(
+  areas: AppDataHookParameters['areas'],
+  seasons: AppDataHookParameters['seasons']
+) {
+  return areas.flatMap((area) => {
+    return seasons.map(([quarter, year]) => {
+      return {
+        __area: area,
+        __year: year,
+        __quarter: quarter,
+
+        network_segments: `./data/replica/${area}/network_segments/${area}_south_atlantic_${year}_${quarter}_network_segments.json.deflate`,
+        population: `./data/replica/${area}/population/${area}_south_atlantic_${year}_${quarter}_population.json.deflate`,
+        saturday_trip: `./data/replica/${area}/saturday_trip/south_atlantic_${year}_${quarter}_saturday_trip.json.deflate`,
+        thursday_trip: `./data/replica/${area}/thursday_trip/south_atlantic_${year}_${quarter}_thursday_trip.json.deflate`,
+      };
+    });
+  });
+}
+
+/**
+ * Returns an array of objects containing promises for fetching replica data for each area and season (per the paths).
+ *
+ * Each function can be aborted by passing an `AbortSignal` to the first argument.
+ *
+ * @param replicaPaths - the returned value of `constructReplicaPaths`
+ */
+function constructReplicaPromises(replicaPaths: ReturnType<typeof constructReplicaPaths>) {
+  return replicaPaths.map(({ __area, __year, __quarter, ...paths }) => {
+    return {
+      __area: async () => __area,
+      __year: async () => __year,
+      __quarter: async () => __quarter,
+      network_segments: (abortSignal?: AbortSignal) =>
+        fetchData<ReplicaNetworkSegments>(paths.network_segments, abortSignal).catch(
+          handleError('network_segments')
+        ),
+      population: (abortSignal?: AbortSignal) =>
+        fetchData<ReplicaSyntheticPeople>(paths.population, abortSignal).catch(
+          handleError('population')
+        ),
+      saturday_trips: (abortSignal?: AbortSignal) =>
+        fetchData<ReplicaTrips>(paths.saturday_trip, abortSignal).catch(
+          handleError('saturday_trip')
+        ),
+      thursday_trips: (abortSignal?: AbortSignal) =>
+        fetchData<ReplicaTrips>(paths.thursday_trip, abortSignal).catch(
+          handleError('thursday_trip')
+        ),
+    };
+  });
+}


### PR DESCRIPTION
Any component that needs to access the data, the loading status, and errors (if they occur) can use `const { data, loading, errors } = useAppData();`

The app data will automatically be re-fetched if the areas or seasons change. Areas and seasons are read from the url search string. For example, `?areas=Brutontown,West%20End&seasons=Q2:2023,Q4:2023,Q2:2024,Q4:2024` causes all data for Q2 2023, Q4 2023, Q2 2024, and Q4 2024 to be fetched from Bruntontown and West End.