### PR TITLE
feat(frontend): add areas and seasons picker to the general access sidebar

### DIFF
--- a/frontend/beforeStart.js
+++ b/frontend/beforeStart.js
@@ -181,7 +181,7 @@ async function buildSeasonIndex(directory) {
     }
   }
 
-  // write the area names to a text file
+  // write the season quarter-year pairs to a text file
   const seasonIndex = seasonNames.join('\n');
   const seasonIndexPath = joinPath(directory, '../../season_index.txt');
   await writeFile(seasonIndexPath, seasonIndex, 'utf8');

--- a/frontend/beforeStart.js
+++ b/frontend/beforeStart.js
@@ -7,7 +7,7 @@ import { deflate as _deflate } from 'zlib';
 const fileExtensionsToRemove = ['.tmp', '.variables'];
 const pipelineDataDir = resolvePath(import.meta.dirname, '../data-pipeline/data');
 const publicDataDir = resolvePath(import.meta.dirname, './public/data');
-const shouldLog = false;
+const shouldLog = true;
 
 console.log('Copying data-pipeline/data to frontend/public/data...');
 
@@ -22,6 +22,10 @@ await cp(pipelineDataDir, publicDataDir, { recursive: true, force: true });
 await removeFileTypes(publicDataDir, fileExtensionsToRemove);
 await discardNonTimeSeriesACS5(publicDataDir + '/census_acs_5year');
 await deflateJsonFiles(publicDataDir);
+const areaNames = await buildAreaIndex(publicDataDir + '/replica');
+if (areaNames.length) {
+  await buildSeasonIndex(publicDataDir + '/replica/' + areaNames[0] + '/thursday_trip');
+}
 
 if (!shouldLog) {
   console.log = originalConsoleLog;
@@ -124,4 +128,62 @@ async function discardNonTimeSeriesACS5(directory) {
   });
 
   await Promise.allSettled(promises);
+}
+
+/**
+ * Builds an index of areas from the list of folder names in data/replica.
+ *
+ * @param {string} directory
+ */
+async function buildAreaIndex(directory) {
+  console.log(`Building area index from directory: ${directory}`);
+  const items = await readdir(directory);
+
+  const areaNames = [];
+  for await (const item of items) {
+    const itemPath = joinPath(directory, item);
+    const stats = await stat(itemPath);
+
+    if (stats.isDirectory()) {
+      areaNames.push(item);
+    }
+  }
+
+  // write the area names to a text file
+  const areaIndex = areaNames.join('\n');
+  const areaIndexPath = joinPath(directory, 'area_index.txt');
+  await writeFile(areaIndexPath, areaIndex, 'utf8');
+  console.log(`Area index written to: ${areaIndexPath}`);
+
+  return areaNames;
+}
+
+/**
+ * Builds an index of seasons from the first area in data/replica.
+ *
+ * @param {string} directory
+ */
+async function buildSeasonIndex(directory) {
+  console.log(`Building seasons index from directory: ${directory}`);
+  const items = await readdir(directory);
+
+  const seasonNames = [];
+  for await (const item of items) {
+    if (item.includes('.json')) {
+      seasonNames.push(
+        item
+          .replace('south_atlantic_', '')
+          .replace('_thursday_trip.json.deflate', '')
+          .split('_')
+          .reverse()
+          .join(':')
+      );
+    }
+  }
+
+  // write the area names to a text file
+  const seasonIndex = seasonNames.join('\n');
+  const seasonIndexPath = joinPath(directory, '../../season_index.txt');
+  await writeFile(seasonIndexPath, seasonIndex, 'utf8');
+  console.log(`Season index written to: ${seasonIndexPath}`);
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,31 +22,38 @@ import {
 export default function App() {
   const [searchParams] = useSearchParams();
 
-  const areas = useMemo(
-    () =>
+  const comparisonEnabled = useMemo(() => {
+    return searchParams.get('compare') === '1';
+  }, [searchParams]);
+
+  const areas = useMemo(() => {
+    const areas =
       searchParams
         .get('areas')
         ?.split(',')
-        .map((str) => str.trim()) ?? [],
-    [searchParams]
-  );
-  const seasons = useMemo(
-    () =>
-      (searchParams.get('seasons')?.split(',') || [])
-        .map((str) => {
-          return str
-            .trim()
-            .split(':')
-            .map((v) => v.trim());
-        })
-        .map(([quarter, year]) => [quarter, parseInt(year)] as const)
-        .filter((v): v is ['Q2' | 'Q4', number] => {
-          const quarter = v[0];
-          const year = v[1];
-          return ['Q2', 'Q4'].includes(quarter) && year >= 2019;
-        }) satisfies Parameters<typeof createAppDataContext>['1'],
-    [searchParams]
-  );
+        .map((str) => str.trim()) ?? [];
+
+    // only use the first area if comparison is not enabled
+    return comparisonEnabled ? areas : areas.slice(0, 1);
+  }, [searchParams, comparisonEnabled]);
+  const seasons = useMemo(() => {
+    const seasons = (searchParams.get('seasons')?.split(',') || [])
+      .map((str) => {
+        return str
+          .trim()
+          .split(':')
+          .map((v) => v.trim());
+      })
+      .map(([quarter, year]) => [quarter, parseInt(year)] as const)
+      .filter((v): v is ['Q2' | 'Q4', number] => {
+        const quarter = v[0];
+        const year = v[1];
+        return ['Q2', 'Q4'].includes(quarter) && year >= 2019;
+      }) satisfies Parameters<typeof createAppDataContext>['1'];
+
+    // only use the first season if comparison is not enabled
+    return comparisonEnabled ? seasons : seasons.slice(0, 1);
+  }, [searchParams, comparisonEnabled]);
 
   return (
     <AppWrapper>

--- a/frontend/src/components/common/SidebarContent/SidebarContent.tsx
+++ b/frontend/src/components/common/SidebarContent/SidebarContent.tsx
@@ -1,0 +1,42 @@
+import styled from '@emotion/styled';
+
+export const SidebarContent = styled.aside`
+  padding: 1rem;
+
+  // enable scrolling within the sidebar if content overflows
+  overflow: auto;
+  box-sizing: border-box;
+  height: 100%;
+
+  // sidebar title
+  h1 {
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--color-text-primary);
+    text-align: left;
+    line-height: 1.2;
+
+    position: sticky;
+    margin: -1rem;
+    top: -1rem;
+    background-color: var(--sidebar-background-color, white);
+    padding: 1.25rem 1rem 0.5rem;
+    border-radius: var(--surface-radius) var(--surface-radius) 0 0;
+  }
+
+  // sidebar section titles
+  h2 {
+    font-size: 0.875rem;
+    font-weight: 600;
+    margin-top: 1.5rem;
+    margin-bottom: 0.25rem;
+    color: var(--color-text-secondary);
+    text-align: left;
+    line-height: 1.2;
+  }
+
+  // field labels
+  label {
+    font-size: 0.875rem;
+  }
+`;

--- a/frontend/src/components/common/index.ts
+++ b/frontend/src/components/common/index.ts
@@ -4,5 +4,6 @@ export { NavBar } from './NavBarItem/NavBar';
 export { NavBarItem } from './NavBarItem/NavBarItem';
 export { Section } from './Section/Section';
 export { SectionEntry } from './Section/SectionEntry';
+export { SidebarContent } from './SidebarContent/SidebarContent';
 export { Tab } from './Tabs/Tab';
 export { Tabs } from './Tabs/Tabs';

--- a/frontend/src/components/layout/CoreFrame/SidebarWrapper.tsx
+++ b/frontend/src/components/layout/CoreFrame/SidebarWrapper.tsx
@@ -80,6 +80,7 @@ export function SidebarWrapper(props: SidebarWrapperProps) {
   return (
     <>
       <FloatingSidebarWrapper isOpen={optionsOpen}>
+        {props.children}
         <CloseButton onClick={() => setOptionsOpen(false)} size="1rem">
           <svg
             width="24"
@@ -94,7 +95,6 @@ export function SidebarWrapper(props: SidebarWrapperProps) {
             />
           </svg>
         </CloseButton>
-        {props.children}
       </FloatingSidebarWrapper>
       {openButton}
       <Scrim
@@ -129,7 +129,8 @@ const FloatingSidebarWrapper = styled.div<{ isOpen?: boolean }>`
   border: 1px solid hsla(0, 0%, 46%, 40%);
   border-radius: var(--surface-radius);
   box-shadow: 0px 32px 64px hsla(0, 0%, 0%, 18.76%), 0px 2px 21px hsl(0, 0%, 0%, 14.74%);
-  background-color: hsl(0, 0%, 98%);
+  --sidebar-background-color: hsl(0, 0%, 98%);
+  background-color: var(--sidebar-background-color);
 
   @container core (max-width: 499px) {
     --width: 100%;

--- a/frontend/src/components/options/areas/SelectedArea.tsx
+++ b/frontend/src/components/options/areas/SelectedArea.tsx
@@ -12,7 +12,11 @@ export function SelectedArea({ areasList }: SelectedAreaProps) {
       Area
       <select onChange={handleAreaSelectionChange} value={selectedArea} style={{ width: '100%' }}>
         {areasList.map((area) => {
-          return <option value={area}>{area}</option>;
+          return (
+            <option key={area} value={area}>
+              {area}
+            </option>
+          );
         })}
       </select>
     </label>

--- a/frontend/src/components/options/areas/SelectedArea.tsx
+++ b/frontend/src/components/options/areas/SelectedArea.tsx
@@ -1,0 +1,20 @@
+import { useSelectedAreasState } from './useSelectedAreasState';
+
+interface SelectedAreaProps {
+  areasList: string[];
+}
+
+export function SelectedArea({ areasList }: SelectedAreaProps) {
+  const { handleAreaSelectionChange, selectedArea } = useSelectedAreasState();
+
+  return (
+    <label>
+      Area
+      <select onChange={handleAreaSelectionChange} value={selectedArea} style={{ width: '100%' }}>
+        {areasList.map((area) => {
+          return <option value={area}>{area}</option>;
+        })}
+      </select>
+    </label>
+  );
+}

--- a/frontend/src/components/options/areas/SelectedArea.tsx
+++ b/frontend/src/components/options/areas/SelectedArea.tsx
@@ -10,7 +10,11 @@ export function SelectedArea({ areasList }: SelectedAreaProps) {
   return (
     <label>
       Area
-      <select onChange={handleAreaSelectionChange} value={selectedArea} style={{ width: '100%' }}>
+      <select
+        onChange={handleAreaSelectionChange}
+        value={selectedArea ?? ''}
+        style={{ width: '100%' }}
+      >
         {areasList.map((area) => {
           return (
             <option key={area} value={area}>

--- a/frontend/src/components/options/areas/SelectedComparisonAreas.tsx
+++ b/frontend/src/components/options/areas/SelectedComparisonAreas.tsx
@@ -1,0 +1,29 @@
+import { useSelectedAreasState } from './useSelectedAreasState';
+
+interface SelectedComparisonAreasProps {
+  areasList: string[];
+}
+
+export function SelectedComparisonAreas({ areasList }: SelectedComparisonAreasProps) {
+  const { comparisonAreas, handleAreaSelectionChange, selectedArea } = useSelectedAreasState();
+
+  return (
+    <label>
+      Areas
+      <select
+        multiple
+        onChange={handleAreaSelectionChange}
+        value={comparisonAreas}
+        style={{ width: '100%' }}
+      >
+        {areasList.map((area) => {
+          return (
+            <option value={area} disabled={area === selectedArea}>
+              {area}
+            </option>
+          );
+        })}
+      </select>
+    </label>
+  );
+}

--- a/frontend/src/components/options/areas/SelectedComparisonAreas.tsx
+++ b/frontend/src/components/options/areas/SelectedComparisonAreas.tsx
@@ -18,7 +18,7 @@ export function SelectedComparisonAreas({ areasList }: SelectedComparisonAreasPr
       >
         {areasList.map((area) => {
           return (
-            <option value={area} disabled={area === selectedArea}>
+            <option key={area} value={area} disabled={area === selectedArea}>
               {area}
             </option>
           );

--- a/frontend/src/components/options/areas/index.ts
+++ b/frontend/src/components/options/areas/index.ts
@@ -1,0 +1,3 @@
+export { SelectedArea } from './SelectedArea';
+export { SelectedComparisonAreas } from './SelectedComparisonAreas';
+export { useSelectedAreasState } from './useSelectedAreasState';

--- a/frontend/src/components/options/areas/useSelectedAreasState.tsx
+++ b/frontend/src/components/options/areas/useSelectedAreasState.tsx
@@ -1,0 +1,29 @@
+import { useSearchParams } from 'react-router';
+
+export function useSelectedAreasState() {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const selectedArea = searchParams.get('areas')?.split(',')?.[0];
+  const comparisonAreas = searchParams.get('areas')?.split(',').slice(1) || [];
+
+  function handleSelectionChange(evt: React.ChangeEvent<HTMLSelectElement>) {
+    const selected = Array.from(evt.target.selectedOptions, (option) => option.value);
+
+    if (evt.target.multiple) {
+      const newComparisonAreas = selected.filter((area) => area !== selectedArea);
+      searchParams.set('areas', [selectedArea, ...newComparisonAreas].join(','));
+    } else {
+      const newSelectedArea = selected[0];
+      const filteredComparisonAreas = comparisonAreas.filter((area) => area !== newSelectedArea);
+      searchParams.set('areas', [newSelectedArea, ...filteredComparisonAreas].join(','));
+    }
+
+    setSearchParams(searchParams);
+  }
+
+  return {
+    selectedArea,
+    comparisonAreas,
+    handleAreaSelectionChange: handleSelectionChange,
+  };
+}

--- a/frontend/src/components/options/compare/ComparisonModeSwitch.tsx
+++ b/frontend/src/components/options/compare/ComparisonModeSwitch.tsx
@@ -1,0 +1,16 @@
+import { useComparisonModeState } from './useComparisonModeState';
+
+export function ComparisonModeSwitch() {
+  const [isCompareEnabled, setIsComparisonEnabled] = useComparisonModeState();
+
+  function handleChangeComparisonMode(evt: React.ChangeEvent<HTMLInputElement>) {
+    setIsComparisonEnabled(evt.target.checked);
+  }
+
+  return (
+    <label style={{ display: 'block' }}>
+      <input type="checkbox" checked={isCompareEnabled} onChange={handleChangeComparisonMode} />
+      Enable comparison mode
+    </label>
+  );
+}

--- a/frontend/src/components/options/compare/index.ts
+++ b/frontend/src/components/options/compare/index.ts
@@ -1,0 +1,2 @@
+export { ComparisonModeSwitch } from './ComparisonModeSwitch';
+export { useComparisonModeState } from './useComparisonModeState';

--- a/frontend/src/components/options/compare/useComparisonModeState.tsx
+++ b/frontend/src/components/options/compare/useComparisonModeState.tsx
@@ -1,0 +1,18 @@
+import { useSearchParams } from 'react-router';
+
+export function useComparisonModeState() {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const isEnabled = searchParams.get('compare') === '1';
+
+  const setIsEnabled = (enabled: boolean) => {
+    if (enabled) {
+      searchParams.set('compare', '1');
+    } else {
+      searchParams.delete('compare');
+    }
+    setSearchParams(searchParams);
+  };
+
+  return [isEnabled, setIsEnabled] as const;
+}

--- a/frontend/src/components/options/index.ts
+++ b/frontend/src/components/options/index.ts
@@ -1,0 +1,3 @@
+export * from './areas';
+export * from './compare';
+export * from './seasons';

--- a/frontend/src/components/options/seasons/SelectedComparisonSeasons.tsx
+++ b/frontend/src/components/options/seasons/SelectedComparisonSeasons.tsx
@@ -19,7 +19,7 @@ export function SelectedComparisonSeasons({ seasonsList }: SelectedComparisonSea
       >
         {seasonsList.map((season) => {
           return (
-            <option value={season} disabled={season === selectedSeason}>
+            <option key={season} value={season} disabled={season === selectedSeason}>
               {season}
             </option>
           );

--- a/frontend/src/components/options/seasons/SelectedComparisonSeasons.tsx
+++ b/frontend/src/components/options/seasons/SelectedComparisonSeasons.tsx
@@ -1,0 +1,30 @@
+import { useSelectedSeasonsState } from './useSelectedSeasonsState';
+
+interface SelectedComparisonSeasonsProps {
+  seasonsList: string[];
+}
+
+export function SelectedComparisonSeasons({ seasonsList }: SelectedComparisonSeasonsProps) {
+  const { comparisonSeasons, handleSeasonSelectionChange, selectedSeason } =
+    useSelectedSeasonsState();
+
+  return (
+    <label>
+      Seasons
+      <select
+        multiple
+        onChange={handleSeasonSelectionChange}
+        value={comparisonSeasons}
+        style={{ width: '100%' }}
+      >
+        {seasonsList.map((season) => {
+          return (
+            <option value={season} disabled={season === selectedSeason}>
+              {season}
+            </option>
+          );
+        })}
+      </select>
+    </label>
+  );
+}

--- a/frontend/src/components/options/seasons/SelectedSeason.tsx
+++ b/frontend/src/components/options/seasons/SelectedSeason.tsx
@@ -1,0 +1,29 @@
+import { useSelectedSeasonsState } from './useSelectedSeasonsState';
+
+interface SelectedSeasonProps {
+  seasonsList: string[];
+}
+
+export function SelectedSeason({ seasonsList }: SelectedSeasonProps) {
+  const { handleSeasonSelectionChange, selectedSeason } = useSelectedSeasonsState();
+
+  return (
+    <label>
+      Reporting window
+      <select
+        onChange={handleSeasonSelectionChange}
+        value={selectedSeason}
+        style={{ width: '100%' }}
+      >
+        {seasonsList.map((season) => {
+          const [quarter, year] = season.split(':');
+          return (
+            <option value={season}>
+              {year} {quarter}
+            </option>
+          );
+        })}
+      </select>
+    </label>
+  );
+}

--- a/frontend/src/components/options/seasons/SelectedSeason.tsx
+++ b/frontend/src/components/options/seasons/SelectedSeason.tsx
@@ -12,7 +12,7 @@ export function SelectedSeason({ seasonsList }: SelectedSeasonProps) {
       Reporting window
       <select
         onChange={handleSeasonSelectionChange}
-        value={selectedSeason}
+        value={selectedSeason ?? ''}
         style={{ width: '100%' }}
       >
         {seasonsList.map((season) => {

--- a/frontend/src/components/options/seasons/SelectedSeason.tsx
+++ b/frontend/src/components/options/seasons/SelectedSeason.tsx
@@ -18,7 +18,7 @@ export function SelectedSeason({ seasonsList }: SelectedSeasonProps) {
         {seasonsList.map((season) => {
           const [quarter, year] = season.split(':');
           return (
-            <option value={season}>
+            <option key={season} value={season}>
               {year} {quarter}
             </option>
           );

--- a/frontend/src/components/options/seasons/index.ts
+++ b/frontend/src/components/options/seasons/index.ts
@@ -1,0 +1,3 @@
+export { SelectedComparisonSeasons } from './SelectedComparisonSeasons';
+export { SelectedSeason } from './SelectedSeason';
+export { useSelectedSeasonsState } from './useSelectedSeasonsState';

--- a/frontend/src/components/options/seasons/useSelectedSeasonsState.ts
+++ b/frontend/src/components/options/seasons/useSelectedSeasonsState.ts
@@ -1,0 +1,31 @@
+import { useSearchParams } from 'react-router';
+
+export function useSelectedSeasonsState() {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const selectedSeason = searchParams.get('seasons')?.split(',')?.[0];
+  const comparisonSeasons = searchParams.get('seasons')?.split(',').slice(1) || [];
+
+  function handleSelectionChange(evt: React.ChangeEvent<HTMLSelectElement>) {
+    const selected = Array.from(evt.target.selectedOptions, (option) => option.value);
+
+    if (evt.target.multiple) {
+      const newComparisonSeasons = selected.filter((season) => season !== selectedSeason);
+      searchParams.set('seasons', [selectedSeason, ...newComparisonSeasons].join(','));
+    } else {
+      const newSelectedSeason = selected[0];
+      const filteredComparisonSeasons = comparisonSeasons.filter(
+        (season) => season !== newSelectedSeason
+      );
+      searchParams.set('seasons', [newSelectedSeason, ...filteredComparisonSeasons].join(','));
+    }
+
+    setSearchParams(searchParams);
+  }
+
+  return {
+    selectedSeason,
+    comparisonSeasons,
+    handleSeasonSelectionChange: handleSelectionChange,
+  };
+}

--- a/frontend/src/hooks/useAppData.ts
+++ b/frontend/src/hooks/useAppData.ts
@@ -61,7 +61,6 @@ function _useAppData({ areas, seasons }: AppDataHookParameters) {
 
   // merge the replica promises with the census promises
   const dataPromises = useMemo(() => {
-    console.log(areas, seasons);
     const replicaPaths = constructReplicaPaths(areas, seasons);
     const replicaPromises = constructReplicaPromises(replicaPaths);
     return replicaPromises.map((promises) => {

--- a/frontend/src/hooks/useAppData.ts
+++ b/frontend/src/hooks/useAppData.ts
@@ -61,6 +61,7 @@ function _useAppData({ areas, seasons }: AppDataHookParameters) {
 
   // merge the replica promises with the census promises
   const dataPromises = useMemo(() => {
+    console.log(areas, seasons);
     const replicaPaths = constructReplicaPaths(areas, seasons);
     const replicaPromises = constructReplicaPromises(replicaPaths);
     return replicaPromises.map((promises) => {
@@ -168,9 +169,8 @@ async function resolveArrayOfPromiseRecords<T extends DataPromises>(
 
 function handleError(key: string) {
   return (error: Error) => {
-    if (!error.message.includes('useAppData is being cleaned up')) {
-      // ignore errors that are caused by the cleanup of the useAppData effect
-      console.error(`Error fetching ${key} data:`, error);
+    // ignore errors that are caused by the cleanup of the useAppData effect
+    if (error.message?.includes('useAppData is being cleaned up')) {
     }
 
     throw new Error(

--- a/frontend/src/hooks/useAppData.ts
+++ b/frontend/src/hooks/useAppData.ts
@@ -21,6 +21,32 @@ interface AppDataHookParameters {
 }
 
 function _useAppData({ areas, seasons }: AppDataHookParameters) {
+  const [areasList, setAreasList] = useState<string[]>([]);
+  useEffect(() => {
+    fetch('./data/replica/area_index.txt')
+      .then((res) => res.text())
+      .then((text) => {
+        const areaList = text
+          .split('\n')
+          .map((line) => line.trim())
+          .filter((line) => line.length > 0);
+        setAreasList(areaList);
+      });
+  }, [setAreasList]);
+
+  const [seasonsList, setSeasonsList] = useState<string[]>([]);
+  useEffect(() => {
+    fetch('./data/replica/season_index.txt')
+      .then((res) => res.text())
+      .then((text) => {
+        const seasonsList = text
+          .split('\n')
+          .map((line) => line.trim())
+          .filter((line) => line.length > 0);
+        setSeasonsList(seasonsList);
+      });
+  }, [setSeasonsList]);
+
   // fetch the census data, which is a static time series file for each category that
   // applies to all areas and seasons
   const censusPromises = useMemo(() => {
@@ -83,7 +109,7 @@ function _useAppData({ areas, seasons }: AppDataHookParameters) {
     };
   }, [dataPromises]);
 
-  return { data, loading, errors };
+  return { data, loading, errors, areasList, seasonsList };
 }
 
 async function fetchData<T = Record<string, unknown>>(
@@ -95,7 +121,9 @@ async function fetchData<T = Record<string, unknown>>(
   })
     .then((response) => {
       if (!response.ok) {
-        throw new Error(`Network response was not ok. Status: ${response.status}, URL: ${response.url}`);
+        throw new Error(
+          `Network response was not ok. Status: ${response.status}, URL: ${response.url}`
+        );
       }
       return response;
     })

--- a/frontend/src/hooks/useAppData.ts
+++ b/frontend/src/hooks/useAppData.ts
@@ -104,7 +104,6 @@ function _useAppData({ areas, seasons }: AppDataHookParameters) {
     }
 
     return () => {
-      console.log('Cleaning up fetch effect in useAppData');
       abortController.abort('fetch effect in useAppData is being cleaned up');
     };
   }, [dataPromises]);
@@ -170,6 +169,8 @@ function handleError(key: string) {
   return (error: Error) => {
     // ignore errors that are caused by the cleanup of the useAppData effect
     if (error.message?.includes('useAppData is being cleaned up')) {
+      console.debug(`Ignoring cleanup error for ${key}:`, error);
+      return null;
     }
 
     throw new Error(

--- a/frontend/src/views/GeneralAccess.tsx
+++ b/frontend/src/views/GeneralAccess.tsx
@@ -19,7 +19,7 @@ export function GeneralAccess() {
       header={<AppNavigation />}
       sidebar={<Sidebar />}
       sections={[
-        <div>
+        <div key="placeholder">
           {loading ? (
             <p>Loading...</p>
           ) : errors ? (

--- a/frontend/src/views/GeneralAccess.tsx
+++ b/frontend/src/views/GeneralAccess.tsx
@@ -1,6 +1,72 @@
+import { useSearchParams } from 'react-router';
 import { CoreFrame } from '../components';
 import { AppNavigation } from '../components/navigation';
+import { useAppData } from '../hooks';
 
 export function GeneralAccess() {
-  return <CoreFrame outerStyle={{ height: '100%' }} header={<AppNavigation />} />;
+  const { data, loading, errors } = useAppData();
+
+  return (
+    <CoreFrame
+      outerStyle={{ height: '100%' }}
+      header={<AppNavigation />}
+      sidebar={<Sidebar />}
+      sections={[
+        <div>
+          {loading ? (
+            <p>Loading...</p>
+          ) : errors ? (
+            <p>Error: {errors.join(', ')}</p>
+          ) : (
+            <div>
+              <h2>General Access Data</h2>
+              <pre>{JSON.stringify(data, null, 2)}</pre>
+            </div>
+          )}
+        </div>,
+      ]}
+    />
+  );
+}
+
+function Sidebar() {
+  const { areasList, seasonsList } = useAppData();
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  function handleAreaChange(evt: React.ChangeEvent<HTMLSelectElement>) {
+    const selectedAreas = Array.from(evt.target.selectedOptions, (option) => option.value);
+    console.log(selectedAreas);
+    searchParams.set('areas', selectedAreas.join(','));
+    setSearchParams(searchParams);
+  }
+
+  function handleSeasonChange(evt: React.ChangeEvent<HTMLSelectElement>) {
+    const selectedSeasons = Array.from(evt.target.selectedOptions, (option) => option.value);
+    console.log(selectedSeasons);
+    searchParams.set('seasons', selectedSeasons.join(','));
+    setSearchParams(searchParams);
+  }
+  return (
+    <aside>
+      <h1>Options</h1>
+
+      <label>
+        Areas
+        <select multiple onChange={handleAreaChange} style={{ width: '100%' }}>
+          {areasList.map((area) => {
+            return <option value={area}>{area}</option>;
+          })}
+        </select>
+      </label>
+
+      <label>
+        Seasons
+        <select multiple onChange={handleSeasonChange} style={{ width: '100%' }}>
+          {seasonsList.map((season) => {
+            return <option value={season}>{season}</option>;
+          })}
+        </select>
+      </label>
+    </aside>
+  );
 }

--- a/frontend/src/views/GeneralAccess.tsx
+++ b/frontend/src/views/GeneralAccess.tsx
@@ -1,6 +1,13 @@
-import { useSearchParams } from 'react-router';
 import { CoreFrame } from '../components';
 import { AppNavigation } from '../components/navigation';
+import {
+  ComparisonModeSwitch,
+  SelectedArea,
+  SelectedComparisonAreas,
+  SelectedComparisonSeasons,
+  SelectedSeason,
+  useComparisonModeState,
+} from '../components/options';
 import { useAppData } from '../hooks';
 
 export function GeneralAccess() {
@@ -20,7 +27,22 @@ export function GeneralAccess() {
           ) : (
             <div>
               <h2>General Access Data</h2>
-              <pre>{JSON.stringify(data, null, 2)}</pre>
+              <pre>
+                {JSON.stringify(
+                  (data || []).map((o) =>
+                    Object.fromEntries(
+                      Object.entries(o).map(([key, value]) => {
+                        if (Array.isArray(value)) {
+                          return [key, `Array(${value.length})`];
+                        }
+                        return [key, value];
+                      })
+                    )
+                  ),
+                  null,
+                  2
+                )}
+              </pre>
             </div>
           )}
         </div>,
@@ -31,42 +53,24 @@ export function GeneralAccess() {
 
 function Sidebar() {
   const { areasList, seasonsList } = useAppData();
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [isComparisonEnabled] = useComparisonModeState();
 
-  function handleAreaChange(evt: React.ChangeEvent<HTMLSelectElement>) {
-    const selectedAreas = Array.from(evt.target.selectedOptions, (option) => option.value);
-    console.log(selectedAreas);
-    searchParams.set('areas', selectedAreas.join(','));
-    setSearchParams(searchParams);
-  }
-
-  function handleSeasonChange(evt: React.ChangeEvent<HTMLSelectElement>) {
-    const selectedSeasons = Array.from(evt.target.selectedOptions, (option) => option.value);
-    console.log(selectedSeasons);
-    searchParams.set('seasons', selectedSeasons.join(','));
-    setSearchParams(searchParams);
-  }
   return (
     <aside>
       <h1>Options</h1>
 
-      <label>
-        Areas
-        <select multiple onChange={handleAreaChange} style={{ width: '100%' }}>
-          {areasList.map((area) => {
-            return <option value={area}>{area}</option>;
-          })}
-        </select>
-      </label>
+      <h2>Filters</h2>
+      <SelectedArea areasList={areasList} />
+      <SelectedSeason seasonsList={seasonsList} />
 
-      <label>
-        Seasons
-        <select multiple onChange={handleSeasonChange} style={{ width: '100%' }}>
-          {seasonsList.map((season) => {
-            return <option value={season}>{season}</option>;
-          })}
-        </select>
-      </label>
+      <h2>Compare</h2>
+      <ComparisonModeSwitch />
+      {isComparisonEnabled ? (
+        <>
+          <SelectedComparisonAreas areasList={areasList} />
+          <SelectedComparisonSeasons seasonsList={seasonsList} />
+        </>
+      ) : null}
     </aside>
   );
 }

--- a/frontend/src/views/GeneralAccess.tsx
+++ b/frontend/src/views/GeneralAccess.tsx
@@ -1,4 +1,4 @@
-import { CoreFrame } from '../components';
+import { CoreFrame, SidebarContent } from '../components';
 import { AppNavigation } from '../components/navigation';
 import {
   ComparisonModeSwitch,
@@ -56,7 +56,7 @@ function Sidebar() {
   const [isComparisonEnabled] = useComparisonModeState();
 
   return (
-    <aside>
+    <SidebarContent>
       <h1>Options</h1>
 
       <h2>Filters</h2>
@@ -71,6 +71,6 @@ function Sidebar() {
           <SelectedComparisonSeasons seasonsList={seasonsList} />
         </>
       ) : null}
-    </aside>
+    </SidebarContent>
   );
 }


### PR DESCRIPTION
This PR adds a picker for the areas and seasons to the general access sidebar. It allows picking a single area or season. If the comparion mode checkbox is checked, it shows a `<select multiple />` for the areas and seasons, allowing more than one area and season to be selected. State is stored in the URL.

![image](https://github.com/user-attachments/assets/d30989cb-0304-45eb-8be9-b0c1adfcd883)
Equivalent URL: `http://localhost:5173/#/?areas=Brutontown%2CWest+End&seasons=Q4%3A2024%2CQ2%3A2021%2CQ4%3A2021&compare=1`

The checkboxes and selects are using the browser styles. We will probably change these to our own styles later.