### PR TITLE
fix(frontend): use esri cdn for arcgis styles

### DIFF
--- a/frontend/src/assets/theme.css
+++ b/frontend/src/assets/theme.css
@@ -1,6 +1,6 @@
-@import '@esri/calcite-components/dist/calcite/calcite.css';
-@import '@arcgis/core/assets/esri/themes/light/main.css';
-@import '@arcgis/map-components/main.css';
+@import 'https://js.arcgis.com/calcite-components/3.2.1/calcite.css';
+@import 'https://js.arcgis.com/4.33/@arcgis/core/assets/esri/themes/light/main.css';
+@import 'https://js.arcgis.com/4.33/map-components/main.css';
 
 :host {
   --color-blue: #222e5d;


### PR DESCRIPTION
This ensures the styles are available outside development mode. Vite was not finding and bundling the CSS from node_modules.