### PR TITLE
fix(frontend): show blank selections for area and season when there is no selection

### DIFF
--- a/frontend/src/components/options/areas/SelectedArea.tsx
+++ b/frontend/src/components/options/areas/SelectedArea.tsx
@@ -15,6 +15,7 @@ export function SelectedArea({ areasList }: SelectedAreaProps) {
         value={selectedArea ?? ''}
         style={{ width: '100%' }}
       >
+        {!selectedArea ? <option key="blank" value=""></option> : null}
         {areasList.map((area) => {
           return (
             <option key={area} value={area}>

--- a/frontend/src/components/options/seasons/SelectedSeason.tsx
+++ b/frontend/src/components/options/seasons/SelectedSeason.tsx
@@ -15,6 +15,7 @@ export function SelectedSeason({ seasonsList }: SelectedSeasonProps) {
         value={selectedSeason ?? ''}
         style={{ width: '100%' }}
       >
+        {!selectedSeason ? <option key="blank" value=""></option> : null}
         {seasonsList.map((season) => {
           const [quarter, year] = season.split(':');
           return (


### PR DESCRIPTION
Previously, the <select> elements showed the first value in the options even though it was not selected. Now, when no option is selected, an empty option is inserted in front of the other options so that the dropdown shows that as the selection. The empty option goes away once a value is actually selected.

In the future, we will have the app set a defauly value in the URL (defaults TBD).