### PR TITLE
chore(frontend): add a `build:gispreview` npm run script that can be used to generate assets to put on a preview server

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "npm run beforestart && vite",
     "build": "npm run beforestart && tsc -b && vite build",
+    "build:gispreview": "NODE_ENV=development npm run build",
     "beforestart": "node beforeStart.js",
     "lint": "eslint .",
     "preview": "vite preview"

--- a/frontend/src/views/DevModeComponentsAll.tsx
+++ b/frontend/src/views/DevModeComponentsAll.tsx
@@ -1,3 +1,4 @@
+import styled from '@emotion/styled';
 import {
   Button,
   CoreFrame,
@@ -255,7 +256,7 @@ export function DevModeComponentsAll() {
       </div>
 
       <h2>Section</h2>
-      <div style={{ display: 'flex', flexDirection: 'row', gap: '1rem' }}>
+      <DevModeSections>
         <Section title="Section Title">
           <SectionEntry>
             <div>Card 1</div>
@@ -305,7 +306,17 @@ export function DevModeComponentsAll() {
             <div>Card 7</div>
           </SectionEntry>
         </Section>
-      </div>
+      </DevModeSections>
     </div>
   );
 }
+
+const DevModeSections = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 1rem;
+
+  div {
+    box-shadow: inset 0 0 1px black;
+  }
+`;


### PR DESCRIPTION
Use the `npm run build:gispreview` to build the frontend to the `dist` folder. Move the contents of this folder to the `inetpub/wwwroot/apps/gc-mobility-dashboard/preview/` folder on the gis server`. Note that you must run `npm run beforestart` if you have not already run it in order to ensure that the data folder is also generated.