### PR TITLE
feat(pipeline/replica): store trips as lines from network segments and derive network segments layer from trips

### DIFF
--- a/.github/actions/prepare-pipeline-test/action.yaml
+++ b/.github/actions/prepare-pipeline-test/action.yaml
@@ -46,8 +46,7 @@ runs:
           INPUT_DIR=$INPUT_DIR \
           ETLS=$ETLS \
           ARTIFACT_NAME=$ARTIFACT_NAME \
-          ACT=${{ env.ACT }} \
-          GITHUB_ACTIONS=${{ env.GITHUB_ACTIONS }} \
+          IS_GH_WORKFLOW=true \
           ./run.sh
       shell: bash
 

--- a/.github/actions/prepare-pipeline-test/action.yaml
+++ b/.github/actions/prepare-pipeline-test/action.yaml
@@ -47,6 +47,7 @@ runs:
           ETLS=$ETLS \
           ARTIFACT_NAME=$ARTIFACT_NAME \
           ACT=${{ env.ACT }} \
+          GITHUB_ACTIONS=${{ env.GITHUB_ACTIONS }} \
           ./run.sh
       shell: bash
 

--- a/.github/actions/prepare-pipeline-test/run.sh
+++ b/.github/actions/prepare-pipeline-test/run.sh
@@ -36,6 +36,8 @@ docker run --rm \
   -e REPLICA_YEARS_FILTER=2023 \
   -e REPLICA_QUARTERS_FILTER=Q4 \
   -e USE_BIGQUERY_STORAGE_API=$SHOULD_USE_BIGQUERY_STORAGE_API \
+  -e GITHUB_ACTIONS=$GITHUB_ACTIONS \
+  -e ACT=$ACT \
   gc-mobility-dashboard-data-pipeline:test --etls=$ETLS
 EXIT_CODE=$?
 if [ $EXIT_CODE -ne 0 ]; then

--- a/.github/actions/prepare-pipeline-test/run.sh
+++ b/.github/actions/prepare-pipeline-test/run.sh
@@ -36,8 +36,7 @@ docker run --rm \
   -e REPLICA_YEARS_FILTER=2023 \
   -e REPLICA_QUARTERS_FILTER=Q4 \
   -e USE_BIGQUERY_STORAGE_API=$SHOULD_USE_BIGQUERY_STORAGE_API \
-  -e GITHUB_ACTIONS=$GITHUB_ACTIONS \
-  -e ACT=$ACT \
+  -e IS_GH_WORKFLOW=$IS_GH_WORKFLOW \
   gc-mobility-dashboard-data-pipeline:test --etls=$ETLS
 EXIT_CODE=$?
 if [ $EXIT_CODE -ne 0 ]; then

--- a/.github/workflows/data-pipeline-test.yaml
+++ b/.github/workflows/data-pipeline-test.yaml
@@ -297,7 +297,7 @@ jobs:
           LAST_PASS_HASH=$(echo "$VARS_JSON" | jq -r --arg key "$BRANCH_VAR_NAME" '.[$key]')
 
           # hash the contents of the current branch (this includes any uncommitted changes when running locally)
-          CURRENT_HASH=$(find . -type f -not -path "*/.vscode/*" -not -path "*/.git/*" \( -exec sha1sum "$PWD"/{} \; \) | awk '{print $1}' | sort | sha1sum | cut -d ' ' -f 1)
+          CURRENT_HASH=$(find . -type f -not -path "*/.vscode/*" -not -path "*/.git/*" -not -path "./data-pipeline/data/*" -not -path "./data-pipeline/env/*" -not -path "./data-pipeline/input/*" \( -exec sha1sum "$PWD"/{} \; \) | awk '{print $1}' | sort | sha1sum | cut -d ' ' -f 1)
           CURRENT_HASH="$CURRENT_HASH$TESTS_TO_RUN_HASH" # append the hash of the tests to run to the current hash
 
           # check whether it matches the current commit hash
@@ -345,6 +345,7 @@ jobs:
           sudo apt-get install -y gh
 
       - name: Update ACT_SUCCESS_COMMIT_HASH (on success)
+        if: "${{ env.ACT }}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -362,7 +363,7 @@ jobs:
           BRANCH_VAR_NAME="ACT_SUCCESS_COMMIT_HASH__${SANITIZED_BRANCH_NAME}"
 
           # hash the contents of the current branch (this includes any uncommitted changes when running locally)
-          CURRENT_HASH=$(find . -type f -not -path "*/.vscode/*" -not -path "*/.git/*" \( -exec sha1sum "$PWD"/{} \; \) | awk '{print $1}' | sort | sha1sum | cut -d ' ' -f 1)
+          CURRENT_HASH=$(find . -type f -not -path "*/.vscode/*" -not -path "*/.git/*" -not -path "./data-pipeline/data/*" -not -path "./data-pipeline/env/*" -not -path "./data-pipeline/input/*" \( -exec sha1sum "$PWD"/{} \; \) | awk '{print $1}' | sort | sha1sum | cut -d ' ' -f 1)
           CURRENT_HASH="$CURRENT_HASH$TESTS_TO_RUN_HASH" # append the hash of the tests to run to the current hash
 
           echo "Setting Repository Variable: $BRANCH_VAR_NAME to $CURRENT_HASH"

--- a/data-pipeline/environment.yaml
+++ b/data-pipeline/environment.yaml
@@ -11,3 +11,4 @@ dependencies:
   - conda-forge::tqdm=4
   - conda-forge::python-dotenv
   - conda-forge::libgdal-arrow-parquet
+  - conda-forge::polars

--- a/data-pipeline/src/etl/sources/replica/etl.py
+++ b/data-pipeline/src/etl/sources/replica/etl.py
@@ -346,8 +346,7 @@ class ReplicaETL:
             return
 
         # check if the etl is running in GitHub Actions
-        is_running_in_workflow = os.getenv('GITHUB_ACTIONS', 'false').lower(
-        ) == 'true' or os.getenv('ACT', 'false').lower() == 'true'
+        is_running_in_workflow = os.getenv('IS_GH_WORKFLOW', 'false').lower() == 'true'
 
         for table_name in schema_df['table_name']:
             # Set full_table_path be equal to the table_name column in the schema_df

--- a/data-pipeline/src/etl/sources/replica/etl.py
+++ b/data-pipeline/src/etl/sources/replica/etl.py
@@ -148,11 +148,11 @@ class ReplicaETL:
 
                 print(f'  Opening source data for season {year} {quarter}')
 
-                print(f'    ...network segments [0/5]')
-                network_segments = geopandas.read_file(os.path.join(
-                    self.folder_path,
-                    expected_parquet_files[0].format(region=region, year=year, quarter=quarter)
-                ))
+                # print(f'    ...network segments [0/5]')
+                # network_segments = geopandas.read_file(os.path.join(
+                #     self.folder_path,
+                #     expected_parquet_files[0].format(region=region, year=year, quarter=quarter)
+                # ))
                 print(f'    ...population data (home) [1/5]')
                 population_home = geopandas.read_file(os.path.join(
                     self.folder_path,

--- a/data-pipeline/src/etl/sources/replica/transformers/count_segment_frequency.py
+++ b/data-pipeline/src/etl/sources/replica/transformers/count_segment_frequency.py
@@ -1,0 +1,94 @@
+from typing import Optional
+
+import geopandas
+import numpy
+
+
+def count_segment_frequency(trips_gdf: geopandas.GeoDataFrame, full_segments_gdf: Optional[geopandas.GeoDataFrame] = None) -> geopandas.GeoDataFrame:
+    """
+    Count the frequency of each segment in the trips GeoDataFrame.
+
+    This removes the first and last segments of each trip, which are typically extremely short lines
+    that indicate the start and end points of the activity, and do not represent actual network segments
+    that should be counted for frequency analysis. It also assigns each segment to a bucket based on
+    its frequency, where 0 represents low frequency and 10 represents the highest frequency.
+
+    Args:
+        trips_gdf (geopandas.GeoDataFrame): GeoDataFrame containing trip segments.
+
+    Returns:
+        geopandas.GeoDataFrame: A new GeoDataFrame with segment geoemtry and their frequencies.
+    """
+    # split each multilinestring into individual linestrings
+    # and create a MultiIndex with activity_id and segment_index
+    exploded = trips_gdf.set_index('activity_id').explode(index_parts=True)  # create a multiindex
+    exploded.index.rename(['activity_id', 'segment_index'], inplace=True)
+
+    # count how many segments each activity has
+    activity_segment_counts = exploded.index.to_frame(index=False).groupby(
+        'activity_id')['segment_index'].max() + 1
+
+    # get the segment indices and activity ids as numpy arrays
+    segment_indices = exploded.index.get_level_values('segment_index')
+    activity_ids = exploded.index.get_level_values('activity_id')
+
+    # Look up the total number of segments for each activity and subtract 1
+    # This gives us the upper bound for the segment index to keep (last segment's index - 1)
+    upper_bound = activity_segment_counts[activity_ids].to_numpy() - 1
+
+    # filter to omit the first and last segments (lines) since these are
+    # short lines that indicate the start and end points of the activity
+    # and do not represent actual netwokr segments
+    filter_condition = (segment_indices > 0) & (segment_indices < upper_bound)
+    filtered_exploded = exploded[filter_condition]
+
+    # count the frequency of each unique segment
+    segment_counts = (
+        filtered_exploded.groupby([filtered_exploded.geometry])
+        .size()
+        .reset_index(name="frequency")
+    )
+
+    # assign each segment to bucket based on its frequency (0 = low frequency, 10 = highest frequency)
+    buckets_count = 10
+    max_frequency = segment_counts['frequency'].max()
+    segment_counts['frequency_bucket'] = numpy.minimum(
+        numpy.ceil(segment_counts['frequency'] / (max_frequency // buckets_count)), buckets_count
+    )
+
+    # convert to a GeoDataFrame
+    segments_gdf = fix_geometry(geopandas.GeoDataFrame(segment_counts))
+
+    # if full_segments_gdf is available, rebase the frequency data on it
+    if full_segments_gdf is not None:
+        full_segments_gdf = fix_geometry(full_segments_gdf)
+        shared_segments_gdf = full_segments_gdf[full_segments_gdf.geometry.isin(
+            segments_gdf.geometry)]
+        shared_segments_gdf = shared_segments_gdf.join(
+            segments_gdf.set_index('geometry'), on='geometry', how='left')
+        return shared_segments_gdf
+
+    return segments_gdf
+
+
+def fix_geometry(gdf: geopandas.GeoDataFrame) -> geopandas.GeoDataFrame:
+    """
+    Fix the geometry of a GeoDataFrame by making it valid.
+
+    Args:
+        gdf (geopandas.GeoDataFrame): GeoDataFrame with geometries to fix.
+
+    Returns:
+        geopandas.GeoDataFrame: GeoDataFrame with fixed geometries.
+    """
+    gdf.geometry = gdf.geometry.make_valid()
+
+    # for some bizarre reason, we have to do this to convince ArcGIS that
+    # the geometry is valid when using parquet files (it will fail to read the file otherwise)
+    geom = gdf.geometry.to_wkb()
+    gdf = geopandas.GeoDataFrame(
+        gdf.drop(columns=['geometry']),
+        geometry=geopandas.GeoSeries.from_wkb(geom, crs="EPSG:4326"),
+    )
+
+    return gdf

--- a/data-pipeline/src/etl/sources/replica/transformers/trips_as_lines.py
+++ b/data-pipeline/src/etl/sources/replica/transformers/trips_as_lines.py
@@ -1,0 +1,178 @@
+import gc
+import logging
+import sys
+from datetime import datetime
+from logging import getLogger
+
+import geopandas
+import pandas
+from shapely.geometry import LineString, MultiLineString
+from tqdm import tqdm
+
+logger = getLogger('replica')
+logger.setLevel(logging.INFO)
+
+
+def create_network_segments_lookup(network_segments_gdf: geopandas.GeoDataFrame) -> dict[str, LineString]:
+    """
+    Create a lookup dictionary for network segments from a GeoDataFrame.
+
+    Args:
+        network_segments_gdf (geopandas.GeoDataFrame): GeoDataFrame containing network segments.
+
+    Returns:
+        dict[str, LineString]: Dictionary mapping stableEdgeId to LineString geometry.
+    """
+    logger.info('Creating segment WKT lookup dictionary...')
+    start_time = datetime.now()
+    segment_lookup: dict[str, LineString] = network_segments_gdf.set_index("stableEdgeId")[
+        "geometry"].to_dict()
+    elapsed_time = datetime.now() - start_time
+    logger.info(
+        f'Created segment WKT lookup dictionary with {len(segment_lookup)} entries in {elapsed_time} seconds.')
+    return segment_lookup
+
+
+def trips_as_lines(trips_df: pandas.DataFrame, network_segments_lookup: dict[str, LineString] | geopandas.GeoDataFrame, crs: str = 'EPSG:4326') -> geopandas.GeoDataFrame:
+    """
+    Convert trips to lines by joining trip points with network segments.
+
+    The start and end points of each trip are included as very short linestrings
+    to ensure the geometry includes the trip start and end points, even if the network segments
+    cannot be fully matched. If any network link IDs are missing, they are recorded in a
+    `missing_network_link_ids` column as a comma-separated string. If all network link IDs
+    are found, this column will be `None`.
+
+    The start and end coordinates must exist as the following columns in the input trip GeoDataFrame:
+    - `start_lng`
+    - `start_lat`
+    - `end_lng`
+    - `end_lat`
+
+    Args:
+        trips_df (pandas.DataFrame): DataFrame containing trips.
+        network_segments_lookup ( dict[str, LineString] | geopandas.GeoDataFrame): A dict of key-value pairs where the key is the entwork segment id and the value is a LineString OR a GeoDataFrame containing network segments. If providing a dict, ensure the LineString geometries are in the same coordinate reference system (CRS) as the trips_df
+        crs (str): Coordinate reference system of the input trips_df data. Defaults to 'EPSG:4326' If network_segments_lookup is a GeoDataFrame and has a different crs, it will be converted.
+
+    Returns:
+        geopandas.GeoDataFrame: GeoDataFrame with trips as lines.
+    """
+
+    tqdm.pandas(file=sys.stdout)
+
+    if 'geometry' in trips_df.columns:
+        logger.warning(
+            "The 'geometry' column already exists in the trips DataFrame. It will be replaced with the new geometry.")
+
+    if isinstance(network_segments_lookup, geopandas.GeoDataFrame):
+        # if the network segments GeoDataFrame has a different CRS than the trips DataFrame, convert it
+        if network_segments_lookup.crs != crs:
+            logger.info(
+                f'Converting network segments GeoDataFrame from {network_segments_lookup.crs} to {crs}...')
+            network_segments_lookup = network_segments_lookup.to_crs(crs)
+
+        # convert to a dictionary for faster lookups of network segments
+        network_segments_lookup = create_network_segments_lookup(network_segments_lookup)
+
+    def get_matching_segments(row: pandas.Series) -> tuple[bytes | None, str | None]:
+        trip_id = row['activity_id']
+        if not isinstance(trip_id, str):
+            logger.warning(
+                f"Trip ID {trip_id} is not a string. Skipping trip.")
+            return (None, None)
+
+        link_ids: list[str] = [link_id.strip()
+                               for link_id in row['network_link_ids'].split(',') if link_id.strip() != '']
+
+        origin_lng = row["start_lng"]
+        origin_lat = row["start_lat"]
+        dest_lng = row["end_lng"]
+        dest_lat = row["end_lat"]
+        if not (isinstance(origin_lng, (float, int)) and isinstance(origin_lat, (float, int)) and isinstance(dest_lng, (float, int)) and isinstance(dest_lat, (float, int))):
+            logger.warning(
+                f"Trip {trip_id} has missing start or end coordinates or the coordinate values are invalud. Skipping trip.")
+            return (None, None)
+
+        # retrieve segments using the lookup dictionary
+        ordered_segments = [
+            network_segments_lookup.get(link_id) for link_id in link_ids
+        ]
+
+        # filter out None values in case a link_id is not found
+        found_segments = [
+            seg for seg in ordered_segments if seg is not None
+        ]
+
+        # create missing links
+        missing_links = None
+        if len(found_segments) != len(link_ids):
+            missing_links = set(link_ids) - set(
+                [
+                    link_id
+                    for link_id, seg in zip(link_ids, ordered_segments)
+                    if seg is not None
+                ]
+            )
+            for link_id in missing_links:
+                logger.debug(
+                    f"Link ID {link_id} from trip {trip_id} not found in network segments."
+                )
+
+        # convert missing_links to a csv to reduce memory usage
+        missing_links_str = None
+        if missing_links:
+            missing_links_str = ','.join(missing_links)
+        del missing_links  # free up memory
+
+        # insert the start and end points of the trip as the first and last segments
+        # as really short linestrings so that the geometry includes the trip start and end points
+        # in case the netwokr segments cannot be fully matched
+        epsilon = 1e-9  # 0.000000001
+        origin_line = LineString([
+            [origin_lng, origin_lat],
+            [origin_lng + epsilon, origin_lat + epsilon]
+        ])
+        dest_line = LineString([
+            [dest_lng + epsilon, dest_lat + epsilon],
+            [dest_lng, dest_lat]
+        ])
+        found_segments = [origin_line] + found_segments + [dest_line]
+
+        # convert the segments to well-known binary (WKB) byte representation of MultiLineString
+        found_segments_wkb = None
+        if found_segments:
+            # converting to bytes instead of keeping as a shapely MultiLineString is slower but way less memory intensive
+            found_segments_wkb = MultiLineString(found_segments).wkb
+
+        # convert the ordered segments into a multilinestring indicating the line geometries as a single multilinestring
+        if found_segments:
+            return (found_segments_wkb, missing_links_str)
+
+        return (None, missing_links_str)
+
+    logger.info(f'Finding matching segments for {len(trips_df)} trips...')
+
+    # Apply the function to each row and unpack the results into new columns
+    # expand: create a new DataFrame with the results for each row
+    apply_results: pandas.DataFrame = trips_df.progress_apply(
+        get_matching_segments, axis=1, result_type='expand')  # type: ignore
+    geometry_wkb: pandas.Series[bytes | None] = apply_results[0]  # type: ignore
+    missing_network_link_ids: pandas.Series[str | None] = apply_results[1]  # type: ignore
+
+    # assign the resultant multilinestring geometry
+    # create a GeoDatFrame from the trips DataFrame and the network segments geometry
+    logger.info('Creating GeoDataFrame with route segment geometries...')
+    geometry = geopandas.GeoSeries.from_wkb(geometry_wkb, crs=crs)
+    gdf = geopandas.GeoDataFrame(trips_df, geometry=geometry)
+
+    # keep track of the missing network link ids, which are returned as csv (when any are misisng) or None (when all are found)
+    gdf['missing_network_link_ids'] = missing_network_link_ids
+
+    # force memory cleanup
+    del apply_results
+    del geometry_wkb
+    del missing_network_link_ids
+    gc.collect()
+
+    # filter out null geometries before returning the new GeoDataFrame
+    return gdf

--- a/data-pipeline/src/main.py
+++ b/data-pipeline/src/main.py
@@ -17,8 +17,7 @@ if __name__ == "__main__":
         docker = True
 
     # check if the script is running in GitHub Actions
-    is_running_in_github_actions = os.getenv(
-        'GITHUB_ACTIONS', 'false').lower() == 'true'
+    is_running_in_workflow = os.getenv('IS_GH_WORKFLOW', 'false').lower() == 'true'
 
     # configure arguments
     parser = argparse.ArgumentParser(
@@ -91,7 +90,7 @@ if __name__ == "__main__":
             print("-" * 78 + '\n\n')
 
             # wait for 10 seconds before continuing
-            if not is_running_in_github_actions:
+            if not is_running_in_workflow:
                 time.sleep(10)
 
     # run the ETL pipeline


### PR DESCRIPTION
This change affects the trips and network segments datasets.

Instead of storing trips layers as two separate layers based on the starting and ending points (and then merging them later after filtering by geogrpahic location), we now find all matching network segments from each trip and set the trip geography to be a multilinestring of the trip route. To ensure that the start and end point are preserved, they are respectively encoded as an extremely short line (1e-9) at the start and end of the multilinestring.

When forming the network segments layer, we now provide separate layers for each trip day (thursday or saturday). Instead of showing all possible network segments, the layer now only shows the segments that were actually used. Each segment also has an attribute for frequency (how many trips used the segment) and frequency bucket (1-10, where each bucket is an equal interval). Frequency bucket can be used to symbolize the segments on a map such that it is possible to see the most frequenctly used network segments.

As part of this change, each chunk from the trips data download is now stored in `./data/replica/full_area/download`. If you need to re-run the ETL and re-download the trip data, you will now need to delete the chunks from the download folder in addition to deleting the compiled layer from `./data/replica/full_area/<day>_trip`. This change was made because saving the chunks to file after completion and then combining them with polars after all downloads completed was significantly more memory-effiicent. 

