### PR TITLE
feat: show polygons for selected areas on the map

### DIFF
--- a/data-pipeline/src/etl/sources/replica/etl.py
+++ b/data-pipeline/src/etl/sources/replica/etl.py
@@ -277,6 +277,24 @@ class ReplicaETL:
 
                     # save the filtered data to files
                     print(f'  Saving filtered data for {area_name}...')
+                    area_polygon_gdf = geopandas.GeoDataFrame(
+                        {'name': [area_name], 'geometry': gdf_union},
+                        crs=gdf.crs
+                    ).to_crs('EPSG:4326')
+                    self._save(
+                        area_polygon_gdf,
+                        area_name,
+                        f'polygon',
+                        '',
+                        'geojson',
+                    )
+                    self._save(
+                        population_home_filtered,
+                        area_name,
+                        f'{region}_{year}_{quarter}_home',
+                        'population',
+                        'geoparquet',
+                    )
                     self._save(
                         population_home_filtered,
                         area_name,

--- a/frontend/src/data.d.ts
+++ b/frontend/src/data.d.ts
@@ -3,6 +3,7 @@ type CensusRaceEthnicityTimeSeries = CensusRaceEthnicityValue[];
 type CensusPopulationTotalTimeSeries = CensusPopulationTotalValue[];
 type CensusEducationalAttainmentTimeSeries = CensusEducationalAttainmentValue[];
 type ReplicaNetworkSegments = GeoJSON<{ frequency: number; frequency_bucket: number }>;
+type ReplicaAreaPolygon = GeoJSON<{ name: string }>;
 type ReplicaSyntheticPeople = ReplicaSyntheticPerson[];
 type ReplicaTrips = ReplicaTrip[];
 

--- a/frontend/src/hooks/useAppData.ts
+++ b/frontend/src/hooks/useAppData.ts
@@ -256,6 +256,7 @@ function constructReplicaPaths(
         __area: area,
         __year: year,
         __quarter: quarter,
+        polygon: `./data/replica/${area}/polygon.geojson.deflate`,
         network_segments: `./data/replica/${area}/network_segments/south_atlantic${networkSegmentsSuffix}.geojson.deflate`,
         population: `./data/replica/${area}/population/south_atlantic_${year}_${quarter}.json.deflate`,
       };
@@ -276,6 +277,8 @@ function constructReplicaPromises(replicaPaths: ReturnType<typeof constructRepli
       __area: async () => __area,
       __year: async () => __year,
       __quarter: async () => __quarter,
+      polygon: (abortSignal?: AbortSignal) =>
+        fetchData<ReplicaAreaPolygon>(paths.polygon, abortSignal).catch(handleError('polygon')),
       network_segments: (abortSignal?: AbortSignal) =>
         fetchData<ReplicaNetworkSegments>(paths.network_segments, abortSignal).catch(
           handleError('network_segments')

--- a/frontend/src/utils/renderers/createInterestAreaRenderer.ts
+++ b/frontend/src/utils/renderers/createInterestAreaRenderer.ts
@@ -1,0 +1,58 @@
+import { SimpleRenderer } from '@arcgis/core/renderers.js';
+import { CIMSymbol } from '@arcgis/core/symbols.js';
+
+export function createInterestAreaRenderer() {
+  return new SimpleRenderer({
+    symbol: new CIMSymbol({
+      data: {
+        type: 'CIMSymbolReference',
+        symbol: {
+          type: 'CIMPolygonSymbol',
+          symbolLayers: [
+            {
+              type: 'CIMSolidStroke',
+              effects: [
+                {
+                  type: 'CIMGeometricEffectOffset',
+                  method: 'Square',
+                  offset: 0,
+                  option: 'Fast',
+                },
+                {
+                  type: 'CIMGeometricEffectDashes',
+                  dashTemplate: [16, 8, 2, 8],
+                  lineDashEnding: 'NoConstraint',
+                  customEndingOffset: 0,
+                  offsetAlongLine: 0,
+                },
+              ],
+              enable: true,
+              capStyle: 'Square',
+              joinStyle: 'Miter',
+              miterLimit: 10,
+              width: 1.5,
+              color: [0, 0, 0, 255],
+            },
+            {
+              type: 'CIMSolidStroke',
+              effects: [
+                {
+                  type: 'CIMGeometricEffectOffset',
+                  method: 'Square',
+                  offset: -1.5,
+                  option: 'Fast',
+                },
+              ],
+              enable: true,
+              capStyle: 'Square',
+              joinStyle: 'Miter',
+              miterLimit: 10,
+              width: 4,
+              color: [0, 0, 0, 40],
+            },
+          ],
+        },
+      },
+    }),
+  });
+}

--- a/frontend/src/utils/renderers/index.ts
+++ b/frontend/src/utils/renderers/index.ts
@@ -1,1 +1,2 @@
+export { createInterestAreaRenderer } from './createInterestAreaRenderer.js';
 export { createScaledSegmentsRenderer } from './createScaledSegmentsRenderer.js';

--- a/frontend/src/views/GeneralAccess.tsx
+++ b/frontend/src/views/GeneralAccess.tsx
@@ -14,7 +14,7 @@ import {
 } from '../components/options';
 import { useAppData } from '../hooks';
 import { notEmpty } from '../utils';
-import { createScaledSegmentsRenderer } from '../utils/renderers';
+import { createInterestAreaRenderer, createScaledSegmentsRenderer } from '../utils/renderers';
 
 export function GeneralAccess() {
   const { data, loading, errors } = useAppData();
@@ -32,6 +32,19 @@ export function GeneralAccess() {
       });
   }, [data]);
 
+  const areaPolygons = useMemo(() => {
+    return (data || [])
+      .map(({ polygon }) => polygon)
+      .filter(notEmpty)
+      .map((polygon) => {
+        return {
+          title: `Area Polygon`,
+          data: polygon,
+          renderer: createInterestAreaRenderer(),
+        } satisfies GeoJSONLayerInit;
+      });
+  }, [data]);
+
   return (
     <CoreFrame
       outerStyle={{ height: '100%' }}
@@ -39,7 +52,7 @@ export function GeneralAccess() {
       sidebar={<Sidebar />}
       map={
         <div style={{ height: '100%' }}>
-          <Map layers={networkSegments} />
+          <Map layers={[...networkSegments, ...areaPolygons]} />
         </div>
       }
       sections={[


### PR DESCRIPTION
This PR adds polygons for the selected area to the map on the genreal access tab. As part of this change, the replica ETL now saves each area's extend polygon to the output folder.