### PR TITLE
feat(pipeline/replica): add statistics for possible conversions to public transit

### DIFF
--- a/.github/workflows/data-pipeline-test.yaml
+++ b/.github/workflows/data-pipeline-test.yaml
@@ -229,7 +229,7 @@ jobs:
           bigquery_credentials: ${{ needs.authenticate_google_big_query.outputs.bigquery_credentials }}
           artifact_name: "data__replica"
           input_dir: "${{ github.workspace }}/replica-input"
-          etls: "replica"
+          etls: "greenlink_gtfs,replica"
 
   test__all:
     name: "Test / All ETLs"

--- a/data-pipeline/src/etl/sources/replica/runner.py
+++ b/data-pipeline/src/etl/sources/replica/runner.py
@@ -3,6 +3,8 @@ from typing import Literal, Optional
 
 from etl.sources.replica.etl import ReplicaETL
 
+after = ['greenlink_gtfs']
+
 
 def source_runner():
     REPLICA_YEARS_FILTER = os.getenv('REPLICA_YEARS_FILTER') or None

--- a/frontend/src/data.d.ts
+++ b/frontend/src/data.d.ts
@@ -183,6 +183,10 @@ interface ReplicaTripStatistics {
     undirected: number;
     other_home_based: number;
   };
+  possible_conversions: {
+    via_walk?: number;
+    via_bike?: number;
+  };
 }
 
 interface ReplicaTripModeStatistics {


### PR DESCRIPTION
There are now totals for non-public transit trips that could have used public transit. These are determined by checking if the entire trip fits within a walking or biking service area, which is generated from the greenlink_gtfs ETL.