### PR TITLE
feat: add service coverge statistics

### DIFF
--- a/data-pipeline/src/etl/geodesic.py
+++ b/data-pipeline/src/etl/geodesic.py
@@ -1,0 +1,191 @@
+from typing import cast
+
+import geopandas
+import pandas
+from geographiclib.geodesic import Geodesic
+from shapely import LineString, Point, Polygon
+
+geod = Geodesic.WGS84  # type: ignore
+
+
+def geodesic_buffer(point: Point, distance_meters: float, num_points: int = 360) -> Polygon | None:
+    """
+    Creates a geodesic buffer around a Shapely Point using geographiclib.
+
+    Args:
+        point (shapely.geometry.Point): The central point (lon, lat in WGS84).
+        distance_meters (float): The buffer distance in meters.
+        num_points (int): Number of points to approximate the circle.
+
+    Returns:
+        shapely.geometry.Polygon: The geodesic buffer polygon.
+    """
+    buffer_points = []
+
+    for i in range(num_points):
+        azimuth = i * (360 / num_points)
+        # see https://geographiclib.sourceforge.io/html/python/code.html?highlight=direct#geographiclib.geodesic.Geodesic.Direct
+        buffer_point = geod.Direct(point.y, point.x, azimuth, distance_meters)
+        # see https://geographiclib.sourceforge.io/html/python/interface.html#dict
+        buffer_points.append((buffer_point['lon2'], buffer_point['lat2']))
+
+    if buffer_points:
+        return Polygon(buffer_points)
+    else:
+        return None
+
+
+def geodesic_buffer_series(points: geopandas.GeoSeries, distance_meters: float, num_points: int = 360) -> geopandas.GeoSeries:
+    """
+    Creates a geodesic buffer around a GeoSeries of Shapely Points using geographiclib.
+
+    The input GeoSeries will be converted to WGS84 (EPSG:4326) before buffering,
+    and then it will be converted back to the original CRS. If the original CRS
+    is missing, it will default to EPSG:4326.
+
+    Args:
+        points (geopandas.GeoSeries): The points to buffer.
+        distance_meters (float): The buffer distance in meters.
+        num_points (int): Number of points to approximate the circle.
+
+    Returns:
+        geopandas.GeoSeries: The geodesic buffer polygons.
+    """
+    results = points.to_crs('EPSG:4326').map(
+        lambda point: geodesic_buffer(point, distance_meters, num_points))
+    return geopandas.GeoSeries(results, crs=points.crs).to_crs(points.crs or 'EPSG:4326')
+
+
+def geodesic_length(line: LineString) -> float:
+    """
+    Solves the inverse geodesic problem for the points in a shapely LineString.
+
+    **The input geometry MUST be in WGS84 (EPSG:4326).**
+    Otherwise, the results will be wrong.
+
+    Args:
+        line: (shapely.geomery.LineString): The line for which distance will be found.
+
+    Returns:
+        float: The distace of the input line in meters.
+    """
+    total_length_meters = 0.0
+
+    for i in range(len(line.coords) - 1):
+        startLongitude, startLatitude = line.coords[i]
+        endLongitude, endLatitude = line.coords[i + 1]
+
+        segment_geod = geod.Inverse(startLatitude, startLongitude, endLatitude, endLongitude)
+        segment_distance = segment_geod['s12']
+        total_length_meters += segment_distance
+
+    return total_length_meters
+
+
+def geodesic_length_series(geoseries: geopandas.GeoSeries) -> float:
+    """
+    Solves the inverse geodesic problem for the points in a geoseries
+    of lines.
+
+    Input geoseries should be in WGS84 (EPSG:4326). If the CRS is
+    not EPSG:4326, it will be converted.
+
+    Args:
+        line: (geopandas.GeoSeries): The series of line geometries for which distance will be found.
+
+    Returns:
+        float: The distace of the input line in meters.
+    """
+
+    # if needed, convert to WGS84 (EPSG:4326)
+    if geoseries.crs is None:
+        raise Exception('CRS must not be missing')
+    if geoseries.crs != 'EPSG:4326':
+        geoseries = geoseries.to_crs('EPSG:4326')
+
+    # extract the LineString and MultiLineString types
+    lines = geoseries[geoseries.geom_type.isin(['LineString', 'MultiLineString'])].copy()
+
+    # convert the MultiLineString types to LineString types
+    lines = lines.explode(index_parts=False)
+    lines = lines[lines.geom_type == 'LineString']  # only keep LineString types
+
+    if lines.empty:
+        return 0.0
+
+    # get the sum of distances for each LineString
+    total_distance = lines\
+        .map(lambda line: geodesic_length(cast(LineString, line)))\
+        .sum()
+
+    return float(total_distance)
+
+
+def geodesic_area(polygon: Polygon) -> tuple[float, float]:
+    """
+    Calculates the geodesic area of a polygon using geographiclib.
+
+    **The input geometry MUST be in WGS84 (EPSG:4326).**
+    Otherwise, the results will be wrong.
+
+    Args:
+        polygon (shapely.geometry.Polygon): The polygon for which area will be found.
+
+    Returns:
+        tuple[float, float]: A tuple containing the perimeter and area of the polygon in meters and square meters, respectively.
+
+    """
+    if not polygon.is_valid:
+        raise ValueError("Invalid polygon geometry")
+
+    # construct a geodesic polygon from the shapely polygon points
+    geodesic_polygon = geod.Polygon()
+    for longitude, latitude in polygon.exterior.coords:
+        geodesic_polygon.AddPoint(latitude, longitude)
+
+    # compute the properties of the geodesic polygon
+    number, perimeter, area = geodesic_polygon.Compute()
+
+    return (perimeter, area)
+
+
+def geodesic_area_series(geoseries: geopandas.GeoSeries) -> tuple[float, float]:
+    """
+    Calculates the geodesic area of a GeoSeries of polygons using geographiclib.
+
+    The input GeoSeries will be converted to WGS84 (EPSG:4326) before calculating the area,
+    and then it will be converted back to the original CRS. If the original CRS
+    is missing, it will default to EPSG:4326.
+
+    Args:
+        polygons (geopandas.GeoSeries): The polygons for which area will be found.
+
+    Returns:
+        tuple[float, float]: A tuple containing the total perimeter and area of the polygons in meters and square meters, respectively.
+    """
+    # if needed, convert to WGS84 (EPSG:4326)
+    if geoseries.crs is None:
+        raise Exception('CRS must not be missing')
+    if geoseries.crs != 'EPSG:4326':
+        geoseries = geoseries.to_crs('EPSG:4326')
+
+    # extract the Polygon and MultiPolygon types
+    polygons = geoseries[geoseries.geom_type.isin(['Polygon', 'MultiPolygon'])].copy()
+
+    # convert the MultiPolygon types to LinePolygonString types
+    polygons = polygons.explode(index_parts=False)
+    polygons = polygons[polygons.geom_type == 'Polygon']  # only keep Polygon types
+
+    if polygons.empty:
+        return (0.0, 0.0)
+
+    # get the perimeters and areas for each Polygon
+    results = polygons.apply(lambda polygon: geodesic_area(cast(Polygon, polygon)))
+    results_df = pandas.DataFrame(results.tolist(), columns=['perimeter', 'area'])
+    results_df['area'] = results_df['area'].abs()  # ensure area is positive
+
+    # sum the results
+    total_perimeter = results_df['perimeter'].sum().astype(float)
+    total_area = results_df['area'].sum().astype(float)
+
+    return (total_perimeter, total_area)

--- a/data-pipeline/src/etl/sources/greenlink_gtfs/runner.py
+++ b/data-pipeline/src/etl/sources/greenlink_gtfs/runner.py
@@ -1,8 +1,14 @@
 import os
+from pathlib import Path
 
 from etl.sources.greenlink_gtfs.etl import GreenlinkGtfsETL
 
 
 def source_runner():
     transitland_api_key = os.getenv('TRANSITLAND_API_KEY', None)
-    GreenlinkGtfsETL().run(transitland_api_key)
+
+    areas_folder = Path('./input/replica_interest_area_polygons')
+    areas_geojson_paths = [file for file in areas_folder.glob(
+        '*.geojson') if file.name != 'full_area.geojson']
+
+    GreenlinkGtfsETL(area_geojson_paths=areas_geojson_paths).run(transitland_api_key)

--- a/frontend/src/data.d.ts
+++ b/frontend/src/data.d.ts
@@ -276,3 +276,17 @@ interface StopRidership {
   alighting: number;
   areas: string[] | null;
 }
+
+interface ServiceCoverage {
+  year: number;
+  quarter: 'Q2' | 'Q4';
+  /** The name of the area. If null, these stats apply to the entire network. */
+  area: string | null;
+  routes_distance_meters: number;
+  walk_service_area_perimeter_meters: number;
+  walk_service_area_area_square_meters: number;
+  bike_service_area_perimeter_meters: number;
+  bike_service_area_area_square_meters: number;
+  paratransit_service_area_perimeter_meters: number;
+  paratransit_service_area_area_square_meters: number;
+}

--- a/frontend/src/data.d.ts
+++ b/frontend/src/data.d.ts
@@ -164,6 +164,10 @@ interface ReplicaSyntheticDemographicsStatisitcs {
     transit?: number;
     biking?: number;
   };
+  households?: number;
+  population?: number;
+  households_in_service_area?: { walk: number; bike: number };
+  population_in_service_area?: { walk: number; bike: number };
 }
 
 interface ReplicaTripStatistics {

--- a/frontend/src/utils/generateHash.ts
+++ b/frontend/src/utils/generateHash.ts
@@ -1,0 +1,9 @@
+export async function generateHash(message: string, algorithm: AlgorithmIdentifier = 'SHA-1') {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(message);
+  const hash = await window.crypto.subtle.digest(algorithm, data);
+  const hashHex = Array.from(new Uint8Array(hash))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+  return hashHex;
+}

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -1,4 +1,5 @@
 export { debounce } from './debounce';
+export { generateHash } from './generateHash';
 export { inflateResponse } from './inflateResponse';
 export { notEmpty } from './notEmpty';
 export { quadraticBezierToPolygon } from './quadraticBezierToPolygon';

--- a/frontend/src/views/GeneralAccess.tsx
+++ b/frontend/src/views/GeneralAccess.tsx
@@ -112,7 +112,20 @@ function Sections() {
         })}
         unit="square miles"
       />
-      <Statistic.Number wrap label="Service coverage (estimated households covered)" data={[]} />
+      <Statistic.Percent
+        wrap
+        label="Household access"
+        data={data?.map((area) => {
+          const area_households = area.statistics?.synthetic_demographics.households || 0;
+          const area_households_covered =
+            area.statistics?.synthetic_demographics.households_in_service_area?.walk || 0;
+
+          return {
+            label: area.__label,
+            value: ((area_households_covered / area_households) * 100).toFixed(1),
+          };
+        })}
+      />
     </Section>,
     <Section title="Area Demographics">
       <Statistic.Number

--- a/frontend/src/views/GeneralAccess.tsx
+++ b/frontend/src/views/GeneralAccess.tsx
@@ -80,12 +80,38 @@ function Sections() {
   return [
     <DeveloperDetails data={data} />,
     <Section title="Service Statistics">
-      <Statistic.Number wrap label="Miles of service" data={[]} />
+      <Statistic.Number
+        wrap
+        label="Miles of service"
+        data={data?.map((area) => {
+          const meters_distance = area.coverage?.routes_distance_meters || 0;
+          const miles_distance = meters_distance / 1609.344; // convert meters to miles
+
+          return {
+            label: area.__label,
+            value: miles_distance.toFixed(2),
+          };
+        })}
+        unit="miles"
+      />
       <Statistic.Number wrap label="Number of stops" data={[]} />
       <Statistic.Number wrap label="Local funding per capita" data={[]} />
       <Statistic.Number wrap label="Boardings" data={[]} />
       <Statistic.Number wrap label="Alightings" data={[]} />
-      <Statistic.Number wrap label="Service coverage (area)" data={[]} />
+      <Statistic.Number
+        wrap
+        label="Service coverage"
+        data={data?.map((area) => {
+          const meters_area = area.coverage?.walk_service_area_area_square_meters || 0;
+          const miles_area = meters_area / 1609.344 / 1609.344; // convert square meters to square miles
+
+          return {
+            label: area.__label,
+            value: miles_area.toFixed(2),
+          };
+        })}
+        unit="square miles"
+      />
       <Statistic.Number wrap label="Service coverage (estimated households covered)" data={[]} />
     </Section>,
     <Section title="Area Demographics">


### PR DESCRIPTION
## Distance- and area-based
Statistics are calculated for the full service area. Statistics are also calculated for each area in input/replica_interest_area_polygons. The output is a JSON file at data/greenlink_gtfs/service_coverage_stats.json

The data in the JSON file are shown on the dashboard on tab 1.

## Population- and household-based

Statistics are included in the synthentic demographics JSON that is already generated by the replica ETL. It follows this structure:

```
households?: number;
population?: number;
households_in_service_areas?: { walk: number; bike: number };
population_in_service_areas?: { walk: number; bike: number };
```

## Screenshot

<img width="518" height="403" alt="image" src="https://github.com/user-attachments/assets/7099a1b2-10e3-4c48-bdae-ea44017a4e80" />
