### PR TITLE
feat(frontend): show boardings and alightings service statistics

### DIFF
--- a/frontend/src/hooks/useAppData.ts
+++ b/frontend/src/hooks/useAppData.ts
@@ -112,6 +112,13 @@ function _useAppData({ areas, seasons, travelMethod }: AppDataHookParameters) {
               (item) => item.year === year && item.quarter === quarter && item.area === area
             );
           }),
+        ridership: (abortSignal?: AbortSignal) =>
+          greenlinkPromisesForSeason.ridership(abortSignal).then((data) => {
+            if (!data) {
+              return null;
+            }
+            return data.filter((stop) => stop.areas?.includes(area));
+          }),
       };
     });
   }, [areas, seasons]);

--- a/frontend/src/views/GeneralAccess.tsx
+++ b/frontend/src/views/GeneralAccess.tsx
@@ -77,6 +77,8 @@ function Sections() {
     ];
   }
 
+  const ridershipDataExists = data?.some((area) => area.ridership) || false;
+
   return [
     <DeveloperDetails data={data} />,
     <Section title="Service Statistics">
@@ -96,8 +98,36 @@ function Sections() {
       />
       <Statistic.Number wrap label="Number of stops" data={[]} />
       <Statistic.Number wrap label="Local funding per capita" data={[]} />
-      <Statistic.Number wrap label="Boardings" data={[]} />
-      <Statistic.Number wrap label="Alightings" data={[]} />
+      {ridershipDataExists ? (
+        <>
+          <Statistic.Number
+            wrap
+            label="Boardings"
+            data={data?.map((area) => {
+              const boardings = area.ridership?.map((stop) => stop.boarding) || [];
+              const boardingsTotal = boardings.reduce((sum, value) => sum + (value || 0), 0);
+
+              return {
+                label: area.__label,
+                value: boardingsTotal,
+              };
+            })}
+          />
+          <Statistic.Number
+            wrap
+            label="Alightings"
+            data={data?.map((area) => {
+              const alightings = area.ridership?.map((stop) => stop.alighting) || [];
+              const alightingsTotal = alightings.reduce((sum, value) => sum + (value || 0), 0);
+
+              return {
+                label: area.__label,
+                value: alightingsTotal,
+              };
+            })}
+          />
+        </>
+      ) : null}
       <Statistic.Number
         wrap
         label="Service coverage"


### PR DESCRIPTION
<img width="1274" height="494" alt="image" src="https://github.com/user-attachments/assets/1ad17808-33aa-4b2b-b703-cf282e795870" />
