### PR TITLE
chore: ignore data folder when it is a symlink

### DIFF
--- a/data-pipeline/.gitignore
+++ b/data-pipeline/.gitignore
@@ -173,7 +173,7 @@ poetry.toml
 pyrightconfig.json
 
 # Data files
-data/
+/data
 
 # Input files - ignort all files in each input folder except README.md files
 /input/*/*


### PR DESCRIPTION
This ignores the data pipeline data folder when it is a symlink to a folder at another location instead of a local folder.