### PR TITLE
feat: add essential services data

### DIFF
--- a/.github/workflows/data-pipeline-test.yaml
+++ b/.github/workflows/data-pipeline-test.yaml
@@ -115,6 +115,8 @@ jobs:
                 RUN_REPLICA_TEST="true"
               elif [[ "$file" == "data-pipeline/src/etl/sources/geocoder/"* ]]; then
                 RUN_GEOCODER_TEST="true"
+              elif [[ "$file" == "data-pipeline/src/etl/sources/essential_services/"* ]]; then
+                RUN_ESSENTIAL_SERVICES_TEST="true"
               elif [[ "$file" == "data-pipeline/src/"* ]] && [[ "$file" != "data-pipeline/src/etl/sources/"* ]]; then
                 RUN_GENERIC_SRC_TEST="true"
               fi
@@ -128,6 +130,7 @@ jobs:
                 RUN_CENSUS_ACS_5YEAR_TEST="false"
                 RUN_REPLICA_TEST="false"
                 RUN_GEOCODER_TEST="false"
+                RUN_ESSENTIAL_SERVICES_TEST="false"
             fi
 
             NO_CHANGES="false"
@@ -142,6 +145,7 @@ jobs:
           echo "run_census_acs_5year=$RUN_CENSUS_ACS_5YEAR_TEST" >> "$GITHUB_OUTPUT"
           echo "run_replica=$RUN_REPLICA_TEST" >> "$GITHUB_OUTPUT"
           echo "run_geocoder=$RUN_GEOCODER_TEST" >> "$GITHUB_OUTPUT"
+          echo "run_essential_services=$RUN_ESSENTIAL_SERVICES_TEST" >> "$GITHUB_OUTPUT"
           echo "run_generic_src=$RUN_GENERIC_SRC_TEST" >> "$GITHUB_OUTPUT"
 
           # hash "$GITHUB_OUTPUT" so we can include it in the check_previous_pass/update_pass_variable CURRENT_HASH variable
@@ -155,6 +159,7 @@ jobs:
           echo "Run Census ACS 5-Year: $RUN_CENSUS_ACS_5YEAR_TEST"
           echo "Run Replica: $RUN_REPLICA_TEST"
           echo "Run Geocoder: $RUN_GEOCODER_TEST"
+          echo "Run Essential Services: $RUN_ESSENTIAL_SERVICES_TEST"
           echo "Run all: $RUN_GENERIC_SRC_TEST"
 
   authenticate_google_big_query:
@@ -328,6 +333,39 @@ jobs:
           etls: "geocoder"
           input_dir: "${{ github.workspace }}/pipeline-input"
 
+  test__essential_services:
+    name: "Test / Essential Services"
+    runs-on: ubuntu-latest
+    needs: [build, determine_tests_to_run]
+    if: needs.determine_tests_to_run.outputs.run_essential_services == 'true'
+    env:
+      CENSUS_API_KEY: ${{ secrets.CENSUS_API_KEY }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Create sample input data
+        env:
+          CSV1_CONTENT: |
+            Company Name,Address,City,State,ZIP Code,ZIP Four,County,Metro Area,Neighborhood
+            7-Eleven,7 Eleven,Fountain Inn,SC,29644,,Greenville,"Greenville, SC",
+            7-Eleven,1703 Easley Bridge Rd,Greenville,SC,29611,5320,Greenville,"Greenville, SC",
+            7-Eleven,2617 Wade Hampton Blvd,Greenville,SC,29615,1149,Greenville,"Greenville, SC",
+        run: |
+          mkdir -p ${{ github.workspace }}/pipeline-input/to_geocode
+
+          cat <<EOF > "${{ github.workspace }}/pipeline-input/to_geocode/grocery_stores__2025-07-18.csv"
+          ${{ env.CSV1_CONTENT }}
+          EOF
+
+      - name: Run test
+        uses: ./.github/actions/prepare-pipeline-test
+        with:
+          artifact_name: "data__essential_services"
+          etls: "geocoder,greenlink_gtfs,replica,essential_services"
+          input_dir: "${{ github.workspace }}/pipeline-input"
+
   test__all:
     name: "Test / All ETLs"
     runs-on: ubuntu-latest
@@ -443,6 +481,8 @@ jobs:
         test__greenlink_ridership,
         test__census_acs_5year,
         test__replica,
+        test__geocoder,
+        test__essential_services,
         test__all,
       ]
     if: ${{ !cancelled() && fromJSON(needs.determine_tests_to_run.outputs.no_changes) != true && fromJSON(needs.check_previous_pass.outputs.successfully_passed) != true }} # always run even if any of the pipeline-related jobs in needs are skipped (skip if there were no tests to run)

--- a/data-pipeline/src/etl/geodesic.py
+++ b/data-pipeline/src/etl/geodesic.py
@@ -1,66 +1,238 @@
-from typing import cast
+from typing import Literal, cast, overload
 
 import geopandas
+import numpy
 import pandas
 from geographiclib.geodesic import Geodesic
-from shapely import LineString, Point, Polygon
+from shapely import LineString, MultiPolygon, Point, Polygon, unary_union
 
-geod = Geodesic.WGS84  # type: ignore
+geod: Geodesic = Geodesic.WGS84  # type: ignore
 
 
-def geodesic_buffer(point: Point, distance_meters: float, num_points: int = 360) -> Polygon | None:
+@overload
+def geodesic_buffer(geom: Point, distance_meters: float, *, num_points: int = 360) -> Polygon: ...
+
+
+@overload
+def geodesic_buffer(geom: Polygon | MultiPolygon, distance_meters: float,
+                    *, join_style: Literal['round', 'bevel'] = 'round') -> Polygon | MultiPolygon: ...
+
+
+def geodesic_buffer(
+    geom: Point | Polygon | MultiPolygon,
+    distance_meters: float,
+    *,
+    num_points: int = 360,
+    join_style: Literal['round', 'bevel'] = 'round'
+) -> Polygon | MultiPolygon | None:
     """
-    Creates a geodesic buffer around a Shapely Point using geographiclib.
+    Creates a geodesic buffer around a Point, Polygon, or MultiPolygon using geographiclib.
 
     Args:
-        point (shapely.geometry.Point): The central point (lon, lat in WGS84).
+        point (shapely.geometry.Point | shapely.geometry.Polygon | shapely.geometry.MultiPolygon): The geometry to buffer (in WGS84).
         distance_meters (float): The buffer distance in meters.
         num_points (int): Number of points to approximate the circle.
 
     Returns:
-        shapely.geometry.Polygon: The geodesic buffer polygon.
+        buffered (shapely.geometry.Polygon | shapely.geometry.MultiPolygon): The geodesic buffer polygon.
     """
-    buffer_points = []
+    # draw a circle around a point
+    if isinstance(geom, Point):
+        circle_points = []
 
-    for i in range(num_points):
-        azimuth = i * (360 / num_points)
-        # see https://geographiclib.sourceforge.io/html/python/code.html?highlight=direct#geographiclib.geodesic.Geodesic.Direct
-        buffer_point = geod.Direct(point.y, point.x, azimuth, distance_meters)
-        # see https://geographiclib.sourceforge.io/html/python/interface.html#dict
-        buffer_points.append((buffer_point['lon2'], buffer_point['lat2']))
+        for i in range(360):
+            azimuth = i * (360 / num_points)
+            # see https://geographiclib.sourceforge.io/html/python/code.html?highlight=direct#geographiclib.geodesic.Geodesic.Direct
+            buffer_point = geod.Direct(geom.y, geom.x, azimuth, distance_meters)
+            # see https://geographiclib.sourceforge.io/html/python/interface.html#dict
+            circle_points.append((buffer_point["lon2"], buffer_point["lat2"]))
 
-    if buffer_points:
-        return Polygon(buffer_points)
-    else:
+        return Polygon(circle_points)
+
+    # offset each line segment of the polygon exterior by the geodesic distance
+    if isinstance(geom, Polygon):
+        exterior_coords = [Point(x, y) for x, y in geom.exterior.coords]
+        exterior_segments = list(zip(exterior_coords[:-1], exterior_coords[1:]))
+        offset_direction = 90 if geom.exterior.is_ccw else -90
+
+        # offset exterior coordinates by the geodesic distance
+        offset_exterior_line_segments: list[list[Point]] = []
+        for start_point, end_point in exterior_segments:
+            offset_points = geodesic_offset(
+                (start_point, end_point),
+                distance_meters,
+                offset_direction
+            )
+            offset_exterior_line_segments.append(offset_points)
+
+        offset_exterior_points: list[Point] = []
+
+        # if we want bevel points, just let shapely  connect the line segments
+        if join_style == 'bevel':
+            for line_points in offset_exterior_line_segments:
+                offset_exterior_points.extend(line_points)
+
+        # otherwise, we need to add arcs between the segments
+        if join_style == 'round':
+            for i in range(len(offset_exterior_line_segments)):
+                current_segment = offset_exterior_line_segments[i]
+                next_segment = offset_exterior_line_segments[(
+                    i + 1) % len(offset_exterior_line_segments)]
+
+                start_point = current_segment[-1]
+                end_point = next_segment[0]
+                unbuffered_vertex = exterior_coords[(i + 1) % len(exterior_coords)]
+
+                arc_points = geodesic_arc(start_point, end_point, unbuffered_vertex)
+                offset_exterior_points.extend(current_segment)
+                offset_exterior_points.extend(arc_points)
+
+        # construct a polygon from the offset exterior points
+        polygon = Polygon(offset_exterior_points)
+        polygon = polygon.buffer(0)  # cleans self-intersections and removes duplicates
+
+        return polygon
+
+    if isinstance(geom, MultiPolygon):
+        buffered_polygons = [
+            geodesic_buffer(polygon, distance_meters) for polygon in geom.geoms
+        ]
+        result = unary_union([g for g in buffered_polygons if g is not None])
+        if isinstance(result, (Polygon, MultiPolygon)):
+            return result
         return None
 
+    return None  # unsupported geometry type
 
-def geodesic_buffer_series(points: geopandas.GeoSeries, distance_meters: float, num_points: int = 360) -> geopandas.GeoSeries:
+
+def geodesic_arc(start_point: Point, end_point: Point, center_point: Point, arc_point_count: int = 8) -> list[Point]:
     """
-    Creates a geodesic buffer around a GeoSeries of Shapely Points using geographiclib.
+    Creates a geodesic arc between two points around a center point.
+
+    Args:
+        start_point (shapely.geometry.Point): The starting point of the arc.
+        end_point (shapely.geometry.Point): The ending point of the arc.
+        center_point (shapely.geometry.Point): The center point around which the arc is drawn.
+        arc_point_count (int): The number of points to generate along the arc.
+
+    Returns:
+        list[shapely.geometry.Point]: A list of points representing the arc.
+    """
+    # calculate the radius of the arc in meters
+    radius_info = geod.Inverse(center_point.y, center_point.x, start_point.y, start_point.x)
+    radius = radius_info['s12']
+
+    # calculate the azimuths connecting the center to the start and end points
+    azimuth_to_start = radius_info['azi1']
+    azimuth_to_end = geod.Inverse(center_point.y, center_point.x, end_point.y, end_point.x)['azi1']
+
+    # find the shortest sweep angle between the two azimuths
+    sweep_angle = (azimuth_to_end - azimuth_to_start) % 360
+    if sweep_angle > 180:
+        sweep_angle -= 360
+
+    # calculate the azimuths for each point along the arc
+    arc_azimuths = numpy.linspace(
+        azimuth_to_start, azimuth_to_start + sweep_angle, arc_point_count)
+
+    # generate the points along the arc
+    arc_points = []
+    for azimuth in arc_azimuths:
+        arc_point_info = geod.Direct(center_point.y, center_point.x, azimuth, radius)
+        arc_point = Point(arc_point_info['lon2'], arc_point_info['lat2'])
+        arc_points.append(arc_point)
+
+    return arc_points
+
+
+def geodesic_interpolate_points(startPoint: Point, endPoint: Point, num_points: int) -> list[Point]:
+    geodesic_info = geod.Inverse(startPoint.y, startPoint.x, endPoint.y, endPoint.x)
+    distance = geodesic_info['s12']
+    azimuth = geodesic_info['azi1']
+
+    # if we do not need to interpolate any points, just return the start and end points
+    if num_points < 1:
+        return [startPoint, endPoint]
+
+    # calculate evently-spaced points along the geodesic line
+    interpolated_points = []
+    distance_between_points = distance / (num_points + 1)
+    for index in range(num_points):
+        distance_from_start_to_interpolated_point = distance_between_points * (index + 1)
+        geodesic_info = geod.Direct(startPoint.y, startPoint.x, azimuth,
+                                    distance_from_start_to_interpolated_point)
+        point_lat, point_lon = geodesic_info['lat2'], geodesic_info['lon2']
+        interpolated_points.append(Point(point_lon, point_lat))
+
+    # return the start point, the interpolated points, and the end point; which represent the geodesic line
+    return [startPoint] + interpolated_points + [endPoint]
+
+
+@overload
+def geodesic_offset(geom: tuple[Point, Point], offset_distance: float,
+                    offset_azimuth: float) -> list[Point]: ...
+
+
+@overload
+def geodesic_offset(geom: Point, offset_distance: float, offset_azimuth: float) -> Point: ...
+
+
+def geodesic_offset(geom: Point | tuple[Point, Point], offset_distance: float, offset_azimuth: float) -> Point | list[Point]:
+
+    # if a single point is provided, we can directly offset it
+    if isinstance(geom, Point):
+
+        result = geod.Direct(geom.y, geom.x, offset_azimuth, offset_distance)
+        return Point(result['lon2'], result['lat2'])
+
+    # solve the inverse geodesic problem for the two points (the line segment)
+    start_point = geom[0]
+    end_point = geom[1]
+    segment_geod = geod.Inverse(start_point.y, start_point.x, end_point.y, end_point.x)
+    segment_distance = segment_geod['s12']
+    segment_azimuth = segment_geod['azi1']
+
+    # for long line segments, we need to interpolate points along the line
+    # so that the offset remains accurate as it arcs over the earth's surface
+    point_interpolation_count = int(segment_distance // 1000)  # interpolate a point for every ~1km
+    line_points = geodesic_interpolate_points(start_point, end_point, point_interpolation_count)
+
+    # offset each point along the line segment
+    offset_points: list[Point] = []
+    for point in line_points:
+        offset_point = geodesic_offset(point, offset_distance, segment_azimuth + offset_azimuth)
+        offset_points.append(offset_point)
+
+    return offset_points
+
+
+def geodesic_buffer_series(geom: geopandas.GeoSeries, distance_meters: float, num_points: int = 360) -> geopandas.GeoSeries:
+    """
+    Creates a geodesic buffer around a GeoSeries of Point, Polygon, or MultiPolygon
+    using geographiclib.
 
     The input GeoSeries will be converted to WGS84 (EPSG:4326) before buffering,
     and then it will be converted back to the original CRS. If the original CRS
     is missing, it will default to EPSG:4326.
 
     Args:
-        points (geopandas.GeoSeries): The points to buffer.
+        geom (geopandas.GeoSeries): The geometry to buffer.
         distance_meters (float): The buffer distance in meters.
-        num_points (int): Number of points to approximate the circle.
+        num_points (int): For Point geometry, the Number of points to approximate the circle.
 
     Returns:
-        geopandas.GeoSeries: The geodesic buffer polygons.
+        buffered_geoseries (geopandas.GeoSeries): The geodesic buffer polygons.
     """
-    original_crs = points.crs or 'EPSG:4326'
-    points = points.to_crs('EPSG:4326')
+    original_crs = geom.crs or 'EPSG:4326'
+    geom = geom.to_crs('EPSG:4326')
 
-    geoseries = points.geometry
-    geoseries = geoseries[geoseries.geom_type.isin(['Point'])].copy()
+    geoseries = geom.geometry
+    geoseries = geoseries[geoseries.geom_type.isin(['Point', 'Polygon', 'MultiPolygon'])].copy()
 
-    results = points.map(lambda point: geodesic_buffer(point, distance_meters,
-                         num_points) if point is not None and point.geom_type == 'Point' else None)
+    results = geom.map(lambda geom: geodesic_buffer(geom, distance_meters,
+                                                    num_points=num_points) if geom is not None and geom.geom_type in ['Point', 'Polygon', 'MultiPolygon'] else None)
 
-    return geopandas.GeoSeries(results, crs=points.crs).to_crs(original_crs)
+    return geopandas.GeoSeries(results, crs='EPSG:4326').to_crs(original_crs)
 
 
 def geodesic_length(line: LineString) -> float:

--- a/data-pipeline/src/etl/geodesic.py
+++ b/data-pipeline/src/etl/geodesic.py
@@ -51,9 +51,16 @@ def geodesic_buffer_series(points: geopandas.GeoSeries, distance_meters: float, 
     Returns:
         geopandas.GeoSeries: The geodesic buffer polygons.
     """
-    results = points.to_crs('EPSG:4326').map(
-        lambda point: geodesic_buffer(point, distance_meters, num_points))
-    return geopandas.GeoSeries(results, crs=points.crs).to_crs(points.crs or 'EPSG:4326')
+    original_crs = points.crs or 'EPSG:4326'
+    points = points.to_crs('EPSG:4326')
+
+    geoseries = points.geometry
+    geoseries = geoseries[geoseries.geom_type.isin(['Point'])].copy()
+
+    results = points.map(lambda point: geodesic_buffer(point, distance_meters,
+                         num_points) if point is not None and point.geom_type == 'Point' else None)
+
+    return geopandas.GeoSeries(results, crs=points.crs).to_crs(original_crs)
 
 
 def geodesic_length(line: LineString) -> float:

--- a/data-pipeline/src/etl/sources/essential_services/etl.py
+++ b/data-pipeline/src/etl/sources/essential_services/etl.py
@@ -1,0 +1,514 @@
+import json
+import logging
+import os
+import shutil
+from pathlib import Path
+from typing import Any, Generator, Iterator, Literal, Self
+
+import geopandas
+import pandas
+import pyogrio
+from pyproj import CRS
+
+from etl.geodesic import geodesic_buffer_series
+
+logger = logging.getLogger('essential_services_etl')
+logger.setLevel(logging.DEBUG)
+
+
+class EssentialServicesETL:
+    replica_folder = Path('data/replica')
+    geocoder_output_folder = Path('data/geocoded')
+    greenlink_gtfs_folder = Path('data/greenlink_gtfs')
+    output_folder = Path('data/essential_services')
+
+    # folder containing subfolders of ISO 8601 dates (no time) which each contain a shapefile of the zoning for that date
+    zoning_input_folder = Path('input/zoning')
+
+    # information related to Greenville County zoning layers
+    commercial_zone_codes = [
+        'C-1',  # local resident commercial
+        'C-2',  # major commercial thoroughfares oriented to customers travelling by automobile
+        'C-3',  # light commercial and service land uses oriented to customers travelling by automobile
+        'S-4',  # services district: commercial use, selling merchandise related to sergices, light industries, and outdoor warehousing
+        'NC',  # convient shopping areas and proffessional offices serving the daily needs of nearby neighborhoods
+    ]
+    zoning_column = 'ZONING'
+
+    # area_name -> trip/population -> season -> stats -> int/float
+    stats: dict[str, dict[str, dict[str, dict[str, int | float | None]]]] = {}
+
+    def __init__(self) -> None:
+        # collect the paths to each area for processing
+        self.areas = [path for path in self.replica_folder.iterdir() if path.is_dir()
+                      and path.name != 'full_area']
+
+        greenlink_gtfs_seasons: list[str] = []
+        for gtfs_year_folder in self.greenlink_gtfs_folder.iterdir():
+            if not gtfs_year_folder.is_dir():
+                continue
+            for gtfs_quarter_folder in gtfs_year_folder.iterdir():
+                if gtfs_quarter_folder.is_dir() and gtfs_quarter_folder.name in ['Q2', 'Q4']:
+                    greenlink_gtfs_seasons.append(
+                        f'{gtfs_year_folder.name}_{gtfs_quarter_folder.name}')
+        self.greenlink_gtfs_seasons = greenlink_gtfs_seasons
+
+        # collect childcare data paths by season
+        childcare_data: dict[str, Path] = {}
+        for path in self.geocoder_output_folder.iterdir():
+            if path.name.startswith('geocoded_childcare__'):
+                year, quarter = extract_season(path.name.split('__')[-1])
+                season = f'{year}_{quarter}'
+                childcare_data[season] = path
+        self.childcare_data = childcare_data
+
+        # collect healthcare data paths by season
+        healthcare_data: dict[str, Path] = {}
+        for path in self.geocoder_output_folder.iterdir():
+            if path.name.startswith('geocoded_healthcare__'):
+                year, quarter = extract_season(path.name.split('__')[-1])
+                season = f'{year}_{quarter}'
+                childcare_data[season] = path
+        self.healthcare_data = healthcare_data
+
+        # collect grocery store data paths by season
+        grocery_store_data: dict[str, Path] = {}
+        for path in self.geocoder_output_folder.iterdir():
+            if path.name.startswith('geocoded_grocery_stores__'):
+                year, quarter = extract_season(path.name.split('__')[-1])
+                season = f'{year}_{quarter}'
+                grocery_store_data[season] = path
+        self.grocery_store_data = grocery_store_data
+
+        # collection zoning data paths by season
+        zoning_data: dict[str, Path] = {}
+        for path in self.zoning_input_folder.iterdir():
+            if path.is_dir():
+                year, quarter = extract_season(path.name)
+                season = f'{year}_{quarter}'
+
+                data_file = next(path.glob('*.shp'), None)
+                if data_file is not None:
+                    # ensure the shapefile is valid and contains the zoning column
+                    try:
+                        gdf = geopandas.read_file(data_file, columns=[self.zoning_column], rows=0)
+                        if self.zoning_column in gdf.columns:
+                            zoning_data[season] = data_file
+                        else:
+                            logger.warning(
+                                f'Zoning shapefile {data_file} does not contain the required column {self.zoning_column}. Skipping...')
+                    except Exception as e:
+                        logger.error(f'Error reading zoning shapefile {data_file}: {e}')
+        self.zoning_data = zoning_data
+
+    def run(self) -> Self:
+        self.calculate_childcare_access(day='thursday')
+        self.calculate_grocery_store_access(day='thursday')
+        self.calculate_commericial_zone_access(day='thursday')
+
+        # flatten the stats dictionary to a list of dictionaries for easier processing
+        logger.info('Flattening stats dictionary for easier processing...')
+        flat_stats: list[dict[str, str | int | float | None]] = []
+        for area, data in self.stats.items():
+            for replica_table, seasons in data.items():
+                for season, stats in seasons.items():
+                    flat: dict[str, str | int | float | None] = {
+                        'area': area,
+                        'replica_table': replica_table,
+                        'season': season
+                    }
+                    for stat_name, value in stats.items():
+                        flat[stat_name] = value
+                    flat_stats.append(flat)
+
+        # convert the flat stats to a pandas DataFrame
+        logger.info('Converting flat stats to pandas DataFrame...')
+        stats_df = pandas.DataFrame(flat_stats)
+
+        # save the stats dataframe to an array of objects in a JSON file
+        stats_output_path = self.output_folder / 'essential_services_stats.json'
+        logger.info(f'Saving stats DataFrame to {stats_output_path}...')
+        stats_output_path.parent.mkdir(parents=True, exist_ok=True)
+        records = [
+            # remove None/null/NA values
+            {key: value for key, value in row.items() if pandas.notna(value)}
+            for row in stats_df.to_dict(orient="records")
+        ]
+        with open(stats_output_path, 'w') as f:
+            json.dump(records, f, indent=2)
+
+        return self
+
+    def get_trip_data(self, area: Path, day: Literal['saturday', 'thursday'] = 'thursday', *, season: str | None = None) -> Generator[tuple[str, Iterator[Path]], Any, None]:
+        """
+        Generator that yields paths to trip data files for a given area and day for each season in the south atlantic region.
+        """
+        season_folders = [path for path in (area / f'{day}_trip').iterdir() if path.is_dir()]
+        seasons = [path.name[-7:len(path.name)] for path in season_folders]
+
+        if season is not None:
+            yield (season, (area / f'{day}_trip' / ('south_atlantic_' + season) / '_chunks').glob('*.parquet'))
+
+        else:
+            for season in seasons:
+                season_parquet_files = (
+                    area / f'{day}_trip' / ('south_atlantic_' + season) / '_chunks').glob('*.parquet')
+                yield (season, season_parquet_files)
+
+    def get_synthetic_population_data(self, area: Path, location: Literal['home', 'school', 'work'], *, season: str | None = None) -> Generator[tuple[str, Path], Any, None]:
+        """
+        Generator that yields paths to trip data files for a given area and day for each season in the south atlantic region.
+        """
+        population_folder = area / 'population'
+        seasons = [path.name[-7:len(path.name)]
+                   for path in population_folder.glob('*_home.parquet')]
+
+        if season is not None:
+            yield (season, population_folder / f'south_atlantic_{season}_{location}.parquet')
+
+        else:
+            for season in seasons:
+                yield (season, population_folder / f'south_atlantic_{season}_{location}.parquet')
+
+    def calculate_childcare_access(self, day: Literal['saturday', 'thursday'] = 'thursday') -> None:
+        return self.calculate_access_to_points_of_interest(
+            day=day,
+            output_name='child_care',
+            data_dict=self.childcare_data,
+            desert_miles=3,  # I picked a generous distance of 3 miles because most definitions use proximity paired with numer of children within census tract geography, which can be significantly smaller in urban areas and significantly bigger in rural areas
+        )
+
+    def calculate_grocery_store_access(self, day: Literal['saturday', 'thursday'] = 'thursday') -> None:
+        return self.calculate_access_to_points_of_interest(
+            day=day,
+            output_name='grocery_store',
+            data_dict=self.grocery_store_data,
+            desert_miles=1,  # the USDA defines a food desert as an area with no grocery store within 1 mile of a household for urban areas
+        )
+
+    def calculate_heathcare_access(self, day: Literal['saturday', 'thursday'] = 'thursday') -> None:
+        return self.calculate_access_to_points_of_interest(
+            day=day,
+            output_name='healthcare',
+            data_dict=self.healthcare_data,
+            # Same as childcare, I picked a generous distance. Most definitions are based on 30-minute drive time, which does not translate super well here.
+            desert_miles=3,
+
+        )
+
+    def calculate_commericial_zone_access(self, day: Literal['saturday', 'thursday'] = 'thursday') -> None:
+        return self.calculate_access_to_points_of_interest(
+            day=day,
+            output_name='commercial_zone',
+            data_dict=self.zoning_data,
+            # filter to commercial zones
+            data_where=f"{self.zoning_column} IN {tuple(self.commercial_zone_codes)}",
+            data_where_columns=[self.zoning_column],
+            desert_miles=1,  # based on food desert definition
+        )
+
+    def calculate_access_to_points_of_interest(
+        self,
+        day: Literal['saturday', 'thursday'] = 'thursday',
+        *,
+        output_name: str,
+        data_dict: dict[str, Path],
+        # A SQL WHERE clause to filter the data. See `pyogrio.read_dataframe` documentation for more details.
+        data_where: str | None = None,
+        # any columns used in the SQL WHERE clause MUST be included here
+        data_where_columns: list[str] = [],
+        desert_miles: int = 1
+    ) -> None:
+        # find the closest avilable POI season for each area dataset
+        logger.info(
+            f'Finding the temporally closest {output_name} data for each season of {day} trip data for each area...')
+        poi_season_per_area_season: dict[str, list[tuple[Path, str]]] = {}
+        for area in self.areas:
+            trip_data = self.get_trip_data(area, day)
+
+            for season, _ in trip_data:
+                # find the closest POI store season
+                closest_poi_season = self.find_closest_season(
+                    season, list(data_dict.keys()))
+
+                if closest_poi_season is None:
+                    logger.warning(
+                        f'No POI data available for season {season} in area {area.name}')
+                    continue
+
+                # store the area path and season in the dictionary
+                if closest_poi_season not in poi_season_per_area_season:
+                    poi_season_per_area_season[closest_poi_season] = []
+                poi_season_per_area_season[closest_poi_season].append((area, season))
+
+        # process each POI data file for its associated area-season pairs
+        logger.info(f'Processing POI data for {day} trip data...')
+        for poi_season, area_season_pairs in poi_season_per_area_season.items():
+            poi_data_path = data_dict[poi_season]
+            year, quarter = poi_season.split('_')
+            logger.info(f'Processing POI data from season {poi_season}...')
+
+            # copy the POI data path to the output folder for reference
+            for area, season in area_season_pairs:
+                season_year, season_quarter = season.split('_')
+                output_poi_folder = self.output_folder / season_year / season_quarter
+                output_poi_folder.mkdir(parents=True, exist_ok=True)
+                file_extension = os.path.splitext(poi_data_path.name)[1]
+                output_poi_path = output_poi_folder / \
+                    (output_name + '.geojson')
+                if not output_poi_path.exists():
+                    logger.debug(f'Copying POI data to {output_poi_path} for reference...')
+                    if file_extension == '.geojson':
+                        shutil.copy(poi_data_path, output_poi_path)
+                    else:
+                        # convert to geojson
+                        poi_gdf = geopandas.read_file(poi_data_path, where=data_where)
+                        poi_gdf.to_crs('EPSG:4326').to_file(output_poi_path, driver='GeoJSON')
+
+            # read the POI geometry (we do not care about the other columns)
+            poi_gdf = geopandas.read_file(poi_data_path, columns=[
+                                          'geometry', *data_where_columns], where=data_where).to_crs('EPSG:4326')
+
+            # require all points or all polygon or multipolygon geometries
+            geometry_type = poi_gdf[poi_gdf.geometry.notna()].geometry.geom_type.unique()
+            if len(geometry_type) > 2:
+                raise ValueError(
+                    f'POI data {poi_data_path} contains mixed geometry types: {geometry_type}. Expected all Point or all Polyon/MultiPolygon.')
+            if len(geometry_type) == 2 and 'Polygon' not in geometry_type and 'MultiPolygon' not in geometry_type:
+                raise ValueError(
+                    f'POI data {poi_data_path} contains mixed geometry types: {geometry_type}. Expected all Point or all Polyon/MultiPolygon.')
+            if len(geometry_type) == 1 and geometry_type[0] not in ['Point', 'Polygon', 'MultiPolygon']:
+                raise ValueError(
+                    f'POI data {poi_data_path} contains unsupported geometry type: {geometry_type[0]}. Expected Point or Polygon/MultiPolygon.')
+            is_point_geometry = geometry_type[0] == 'Point'
+
+            logger.info('Generating destination zones geometry...')
+            if is_point_geometry:
+                # buffer the geometry by 400 meters (~ 0.25 miles) to determine the zones
+                # that represent possible trip destinations to each POI
+                destination_zones = geopandas.GeoDataFrame(
+                    geometry=geodesic_buffer_series(poi_gdf.geometry, 400),
+                    crs=poi_gdf.crs
+                )
+            else:
+                # if the geometry is a polygon or multipolygon, we can use it directly as the destination zones
+                destination_zones = poi_gdf[poi_gdf.geometry.notna(
+                )]
+
+            # calculate mean travel time to a POI in the area-season via public transit
+            for area, season in area_season_pairs:
+                logger.info(
+                    f'Calculating mean public transit travel time to POIs for area {area.name} in season {season}...')
+                trip_files = next(self.get_trip_data(area, day, season=season))[1]
+
+                # since we a reading in chunks, we need to keep track of the travel duration for each trip accross all chunks
+                # in a dictionary where the keys are the times (as integer) and the values are the number of trips with that time
+                time_frequencies: dict[int, int] = {}
+
+                destination_zones_for_area = destination_zones.copy()
+
+                # count the time taken for each public transit trip to a POI
+                for trip_file in trip_files:
+                    dest_columns = ['mode', 'travel_purpose', 'duration_minutes']
+                    dest_gdf = read_as_point_geometry(trip_file, xy_columns=(
+                        'end_lng', 'end_lat'), xy_crs='EPSG:4326', columns=dest_columns, filters=[('mode', '==', 'PUBLIC_TRANSIT')])
+
+                    # TODO: move this logic to the ETL where it is first downloaded
+                    dest_gdf['mode'] = dest_gdf['mode'].astype('category')
+                    dest_gdf['travel_purpose'] = dest_gdf['travel_purpose'].astype('category')
+                    dest_gdf['duration_minutes'] = dest_gdf['duration_minutes'].astype('short')
+
+                    # filter to trip desinations that are within the POI buffers
+                    near_poi_destinations = geopandas.sjoin(
+                        dest_gdf, destination_zones_for_area, how='inner', predicate='within')
+
+                    # count found destinations per zone and add to destination_zones_for_area
+                    if not near_poi_destinations.empty:
+                        # count destinations by zone index
+                        zone_counts = near_poi_destinations.groupby('index_right').size()
+
+                        # initialize found_count column if it doesn't exist
+                        if 'found_count' not in destination_zones_for_area.columns:
+                            destination_zones_for_area['found_count'] = 0
+
+                        # increment counts for zones that had destinations
+                        for zone_idx, count in zone_counts.items():
+                            idx = zone_idx if isinstance(zone_idx, int) else int(str(zone_idx))
+                            current_count = destination_zones_for_area.loc[idx, 'found_count']
+                            destination_zones_for_area.loc[idx, 'found_count'] = int(
+                                str(current_count)) + count
+
+                    # remove destination points that o=are duplicates (e.g., they are within multiple zones)
+                    near_poi_destinations = near_poi_destinations[
+                        ~near_poi_destinations.index.duplicated(keep="first")
+                    ]
+
+                    # add the travel time for each trip to the time_frequencies dictionary
+                    durations_frequencies = near_poi_destinations.groupby(
+                        'duration_minutes').size().to_dict()
+                    for duration, frequency in durations_frequencies.items():
+                        if duration in time_frequencies:
+                            time_frequencies[duration] += frequency
+                        else:
+                            time_frequencies[duration] = frequency
+
+                logger.info(
+                    f'Saving POI destination geometry for area {area.name} in season {season}...')
+                area_season_year, area_season_quarter = season.split('_')
+                output_folder = self.output_folder / area_season_year / area_season_quarter / area.name
+                output_folder.mkdir(parents=True, exist_ok=True)
+                destination_zones_for_area.to_file(
+                    output_folder / f'{output_name}__destination_zones.geojson', index=False)
+
+                # calculate the mean travel time for this area-season pair
+                weighted_sum = sum(duration * frequency for duration,
+                                   frequency in time_frequencies.items())
+                total_trips = sum(time_frequencies.values())
+                if total_trips > 0:
+                    mean_travel_time = weighted_sum / total_trips
+                else:
+                    mean_travel_time = None
+
+                self.stats.setdefault(area.name, {})
+                self.stats[area.name].setdefault(f'{day}_trip', {})
+                self.stats[area.name][f'{day}_trip'].setdefault(season, {})
+                self.stats[area.name][f'{day}_trip'][season][f'{output_name}__mean_travel_time'] = mean_travel_time
+
+            logger.info(f'Generating access zones geometry...')
+            # buffer the geometry by 1 mile to determine the zone that indicates
+            # reasonable access to each POI
+            mile_in_meters = 1609.344
+            access_zones = geopandas.GeoDataFrame(
+                geometry=geodesic_buffer_series(
+                    poi_gdf.geometry, desert_miles * mile_in_meters),
+                crs=poi_gdf.crs
+            ).dissolve().explode().reset_index(drop=True)
+
+            # clip the access zones to the walk_serivce_area so it excludes people
+            # who do not live within reasonable walking distance of bus stops
+            walk_service_area_season = self.find_closest_season(
+                f'{year}_{quarter}',
+                self.greenlink_gtfs_seasons
+            )
+            if walk_service_area_season is None:
+                logger.warning(
+                    f'No walk service area data available for season {year}_{quarter}. Skipping proportional access calculation...')
+                continue
+            wsa_year, wsa_quarter = walk_service_area_season.split('_')
+            walk_service_area_gdf = geopandas.read_file(
+                self.greenlink_gtfs_folder / wsa_year / wsa_quarter / 'walk_service_area.geojson').to_crs('EPSG:4326')
+            access_zones = geopandas.overlay(
+                access_zones, walk_service_area_gdf, how='intersection')
+
+            # calculate the proportion of the population with reasonable access to at least one POI
+            for area, season in area_season_pairs:
+                logger.info(
+                    f'Calculating proportion of population with access to at least one POI for area {area.name} in season {season}...')
+
+                access_zones_for_area = access_zones.copy()
+
+                logger.debug(
+                    f'Reading synthetic population home locations for area {area.name} in season {season}...')
+                population_data_path = next(
+                    self.get_synthetic_population_data(area, 'home', season=season))[1]
+                population_home_locations = geopandas.read_file(
+                    population_data_path, columns=['geometry']).to_crs('EPSG:4326').reset_index()
+
+                logger.debug(
+                    f'Filtering population home locations to those within the POI access zones for area {area.name} in season {season}...')
+                population_within_access = geopandas.sjoin(
+                    population_home_locations, access_zones_for_area, how='inner', predicate='within')
+
+                # count found population per zone and add to destination_zones_for_area
+                if not population_within_access.empty:
+                    # count destinations by zone index
+                    zone_counts = population_within_access.groupby('index_right').size()
+
+                    # initialize found_count column if it doesn't exist
+                    if 'found_count' not in access_zones_for_area.columns:
+                        access_zones_for_area['found_count'] = 0
+
+                    # increment counts for zones that had destinations
+                    for zone_idx, count in zone_counts.items():
+                        idx = zone_idx if isinstance(zone_idx, int) else int(str(zone_idx))
+                        current_count = access_zones_for_area.loc[idx, 'found_count']
+                        access_zones_for_area.loc[idx, 'found_count'] = int(
+                            str(current_count)) + count
+
+                logger.info(
+                    f'Saving POI access geometry for area {area.name} in season {season}...')
+                area_season_year, area_season_quarter = season.split('_')
+                output_folder = self.output_folder / area_season_year / area_season_quarter / area.name
+                output_folder.mkdir(parents=True, exist_ok=True)
+                access_zones.to_file(
+                    output_folder / f'{output_name}__access.geojson', index=False)
+
+                proportion_with_access = len(population_within_access) / \
+                    len(population_home_locations)
+                self.stats.setdefault(area.name, {})
+                self.stats[area.name].setdefault('population', {})
+                self.stats[area.name]['population'].setdefault(season, {})
+                self.stats[area.name]['population'][season][f'{output_name}__access_fraction'] = proportion_with_access
+
+    def find_closest_season(self, target_season: str, available_seasons: list[str]) -> str | None:
+        """
+        Finds the closest season to the target season from the available seasons.
+        Seasons are in the format 'YYYY_Q2' or 'YYYY_Q4'.
+        """
+        target_year_str, target_quarter = target_season.split('_')
+        target_year = int(target_year_str)
+
+        # if there is a perfect match, return it
+        if target_season in available_seasons:
+            return target_season
+
+        # sort available seasons by year and quarter
+        available_seasons.sort(key=lambda s: (int(s.split('_')[0]), s.split('_')[1]))
+
+        # split the available seasons into years and quarters
+        available_season_parts_ = [season.split('_') for season in available_seasons]
+        available_season_parts = [(int(year), quarter)
+                                  for year, quarter in available_season_parts_]
+
+        # find the closest season
+        closest_season: str | None = None
+        closest_distance = float('inf')
+        for year, quarter in available_season_parts:
+            distance = abs(year - target_year) + (0 if quarter == target_quarter else 1)
+            if distance < closest_distance:
+                closest_distance = distance
+                closest_season = f'{year}_{quarter}'
+
+        return closest_season
+
+
+def extract_season(iso8601_date: str) -> tuple[int, Literal['Q2', 'Q4']]:
+    """
+    Extracts the year and season (Q2 or Q4) from an ISO 8601 date string.
+
+    Args:
+        iso8601_date (str): The ISO 8601 date string. DO NOT include the time part.
+
+    Returns:
+        tuple[int, Literal['Q2', 'Q4']]: A tuple containing the year and season.
+    """
+    year = int(iso8601_date[:4])
+    month = int(iso8601_date[5:7])
+    season: Literal['Q2', 'Q4'] = 'Q2' if month in [1, 2, 3, 4, 5, 6] else 'Q4'
+    return (year, season)
+
+
+def read_as_point_geometry(path: Path | str, xy_columns: tuple[str, str], xy_crs: CRS | str, *, columns: list[str], filters: list[tuple[str, str, str]] | None = None) -> geopandas.GeoDataFrame:
+    # read the CRS from the geoparquet file since we will lose it when we read it with pandas instead of geopandas
+    metadata = pyogrio.read_info(path)
+    crs = metadata['crs']
+
+    # read the data with pandas
+    columns_to_read = [*columns, *xy_columns]
+    df = pandas.read_parquet(path, columns=columns_to_read, filters=filters)
+
+    # convert to a GeoDataFrame where the xy_columns are used for the point geometry
+    gdf = geopandas.GeoDataFrame(df, geometry=geopandas.points_from_xy(
+        df[xy_columns[0]], df[xy_columns[1]]), crs=xy_crs, columns=columns)
+
+    return gdf

--- a/data-pipeline/src/etl/sources/essential_services/etl.py
+++ b/data-pipeline/src/etl/sources/essential_services/etl.py
@@ -31,7 +31,7 @@ class EssentialServicesETL:
         'C-2',  # major commercial thoroughfares oriented to customers travelling by automobile
         'C-3',  # light commercial and service land uses oriented to customers travelling by automobile
         'S-4',  # services district: commercial use, selling merchandise related to sergices, light industries, and outdoor warehousing
-        'NC',  # convient shopping areas and proffessional offices serving the daily needs of nearby neighborhoods
+        'NC',  # convenient shopping areas and professional offices serving the daily needs of nearby neighborhoods
     ]
     zoning_column = 'ZONING'
 
@@ -104,7 +104,7 @@ class EssentialServicesETL:
     def run(self) -> Self:
         self.calculate_childcare_access(day='thursday')
         self.calculate_grocery_store_access(day='thursday')
-        self.calculate_commericial_zone_access(day='thursday')
+        self.calculate_commercial_zone_access(day='thursday')
 
         # flatten the stats dictionary to a list of dictionaries for easier processing
         logger.info('Flattening stats dictionary for easier processing...')
@@ -196,7 +196,7 @@ class EssentialServicesETL:
 
         )
 
-    def calculate_commericial_zone_access(self, day: Literal['saturday', 'thursday'] = 'thursday') -> None:
+    def calculate_commercial_zone_access(self, day: Literal['saturday', 'thursday'] = 'thursday') -> None:
         return self.calculate_access_to_points_of_interest(
             day=day,
             output_name='commercial_zone',

--- a/data-pipeline/src/etl/sources/essential_services/etl.py
+++ b/data-pipeline/src/etl/sources/essential_services/etl.py
@@ -68,7 +68,7 @@ class EssentialServicesETL:
             if path.name.startswith('geocoded_healthcare__'):
                 year, quarter = extract_season(path.name.split('__')[-1])
                 season = f'{year}_{quarter}'
-                childcare_data[season] = path
+                healthcare_data[season] = path
         self.healthcare_data = healthcare_data
 
         # collect grocery store data paths by season

--- a/data-pipeline/src/etl/sources/essential_services/etl.py
+++ b/data-pipeline/src/etl/sources/essential_services/etl.py
@@ -82,23 +82,25 @@ class EssentialServicesETL:
 
         # collection zoning data paths by season
         zoning_data: dict[str, Path] = {}
-        for path in self.zoning_input_folder.iterdir():
-            if path.is_dir():
-                year, quarter = extract_season(path.name)
-                season = f'{year}_{quarter}'
+        if self.zoning_input_folder.exists():
+            for path in self.zoning_input_folder.iterdir():
+                if path.is_dir():
+                    year, quarter = extract_season(path.name)
+                    season = f'{year}_{quarter}'
 
-                data_file = next(path.glob('*.shp'), None)
-                if data_file is not None:
-                    # ensure the shapefile is valid and contains the zoning column
-                    try:
-                        gdf = geopandas.read_file(data_file, columns=[self.zoning_column], rows=0)
-                        if self.zoning_column in gdf.columns:
-                            zoning_data[season] = data_file
-                        else:
-                            logger.warning(
-                                f'Zoning shapefile {data_file} does not contain the required column {self.zoning_column}. Skipping...')
-                    except Exception as e:
-                        logger.error(f'Error reading zoning shapefile {data_file}: {e}')
+                    data_file = next(path.glob('*.shp'), None)
+                    if data_file is not None:
+                        # ensure the shapefile is valid and contains the zoning column
+                        try:
+                            gdf = geopandas.read_file(
+                                data_file, columns=[self.zoning_column], rows=0)
+                            if self.zoning_column in gdf.columns:
+                                zoning_data[season] = data_file
+                            else:
+                                logger.warning(
+                                    f'Zoning shapefile {data_file} does not contain the required column {self.zoning_column}. Skipping...')
+                        except Exception as e:
+                            logger.error(f'Error reading zoning shapefile {data_file}: {e}')
         self.zoning_data = zoning_data
 
     def run(self) -> Self:

--- a/data-pipeline/src/etl/sources/essential_services/runner.py
+++ b/data-pipeline/src/etl/sources/essential_services/runner.py
@@ -1,0 +1,7 @@
+from etl.sources.essential_services.etl import EssentialServicesETL
+
+after = ['greenlink_gtfs', 'geocoder']
+
+
+def source_runner():
+    EssentialServicesETL().run()

--- a/data-pipeline/src/etl/sources/geocoder/etl.py
+++ b/data-pipeline/src/etl/sources/geocoder/etl.py
@@ -1,70 +1,71 @@
-import pandas
-import geopandas
-import requests
 import json
 import time
 from pathlib import Path
+
+import geopandas
+import pandas
+import requests
 from shapely.geometry import Point
 
 
 class GeocoderETL:
     """Robust geocoding ETL with ArcGIS and Nominatim fallback."""
-    
+
     input_folder = Path('./input/to_geocode')
     output_folder = Path('./data/geocoded')
     geocoder_url = "https://www.gcgis.org/arcgis/rest/services/GVL_COMPOSITE_LOC/GeocodeServer/geocodeAddresses"
     nominatim_url = "https://nominatim.openstreetmap.org/search"
-    
+
     def __init__(self):
         self.output_folder.mkdir(parents=True, exist_ok=True)
-        
+
     def run(self) -> bool:
         try:
             csv_files = list(self.input_folder.glob("*.csv"))
             if not csv_files:
                 print(f"⚠ No CSV files found in {self.input_folder}")
-                return False
+                return True
         except Exception as e:
             print(f"⚠ Cannot access input folder: {e}")
             return False
-        
-        success = True
-        
+
+        success = False
+
         for file in csv_files:
             print(f"Processing {file.name}...")
-            
+
             try:
                 # Read and validate CSV
                 try:
                     df = pandas.read_csv(file, on_bad_lines='skip')
                 except UnicodeDecodeError:
                     df = pandas.read_csv(file, on_bad_lines='skip', encoding='latin-1')
-                
+
                 if df.empty:
                     print(f"⚠ {file.name} is empty")
                     success = False
                     continue
-                
+
                 # Standardize columns
                 col_map = {'ZIP Code': 'ZIP', 'Street': 'Address', 'Zip': 'ZIP'}
                 df = df.rename(columns=col_map)
-                
+
                 if 'Address' not in df.columns:
                     print(f"⚠ {file.name} missing Address/Street column")
                     success = False
                     continue
-                
+
                 # Clean data
                 df = df.dropna(subset=['Address']).reset_index(drop=True)
                 df = df[df['Address'].astype(str).str.strip().str.len() > 0].reset_index(drop=True)
-                
+
                 if df.empty:
                     print(f"⚠ {file.name} has no valid addresses")
                     success = False
                     continue
-                
+
                 print(f"✔ Geocoding {len(df)} addresses")
-                
+
                 # Primary ArcGIS geocoding
                 try:
                     # Build request
@@ -77,31 +78,32 @@ class GeocoderETL:
                             except:
                                 attrs["ZIP"] = str(row['ZIP']).strip()
                         records.append({"attributes": attrs})
-                    
+
                     # Send request
-                    data = {'addresses': json.dumps({"records": records}), 'f': 'json', 'outSR': '4326'}
+                    data = {'addresses': json.dumps(
+                        {"records": records}), 'f': 'json', 'outSR': '4326'}
                     response = requests.post(self.geocoder_url, data=data, timeout=60)
-                    
+
                     if response.status_code != 200:
                         raise Exception(f"ArcGIS returned {response.status_code}")
-                    
+
                     result = response.json()
                     if 'locations' not in result:
                         raise Exception("No locations in ArcGIS response")
-                    
+
                     # Process ArcGIS results
                     geocode_results = []
                     failed_addresses = []
                     successful_count = 0
-                    
+
                     for loc in result['locations']:
                         idx = loc['attributes']['ResultID']
-                        
-                        if (loc.get('location') and 
+
+                        if (loc.get('location') and
                             str(loc['location'].get('x', 'NaN')).lower() != 'nan' and
                             str(loc['location'].get('y', 'NaN')).lower() != 'nan' and
-                            loc.get('score', 0) > 0):
-                            
+                                loc.get('score', 0) > 0):
+
                             try:
                                 x, y = float(loc['location']['x']), float(loc['location']['y'])
                                 if -180 <= x <= 180 and -90 <= y <= 90:
@@ -113,22 +115,22 @@ class GeocoderETL:
                                 geom = None
                         else:
                             geom = None
-                        
+
                         geocode_results.append({'index': idx, 'geometry': geom})
-                        
+
                         if not geom and idx < len(df):
                             row = df.iloc[idx].copy()
                             row['nominatim_success'] = False
                             failed_addresses.append(row)
-                
+
                 except Exception as e:
                     print(f"⚠ ArcGIS geocoding failed: {e}")
                     geocode_results = [{'index': i, 'geometry': None} for i in range(len(df))]
                     failed_addresses = df.to_dict('records')
                     successful_count = 0
-                
+
                 print(f"✔ ArcGIS: {successful_count} successful, {len(failed_addresses)} failed")
-                
+
                 # Nominatim fallback
                 if failed_addresses:
                     print(f"*Trying Nominatim for {len(failed_addresses)} failed addresses")
@@ -136,59 +138,62 @@ class GeocoderETL:
                     successful_count += rescued
                     if rescued > 0:
                         print(f"✔ Nominatim rescued {rescued} addresses")
-                
+
                 print(f"✔ Final: {successful_count}/{len(df)} successful")
-                
+
                 # Merge and save results
                 try:
                     result_df = pandas.DataFrame(geocode_results)
-                    merged = pandas.merge(df.reset_index(), result_df, on='index', how='left').set_index('index')
-                    
+                    merged = pandas.merge(df.reset_index(), result_df,
+                                          on='index', how='left').set_index('index')
+
                     gdf = geopandas.GeoDataFrame(merged, crs='EPSG:4326')
                     output_file = self.output_folder / f"geocoded_{file.stem}.geojson"
                     gdf.to_file(output_file, driver='GeoJSON')
                     print(f"✔ Saved to {output_file}")
-                    
+
                     # Save failed addresses
-                    final_failed = [f for f in failed_addresses if not f.get('nominatim_success', False)]
+                    final_failed = [f for f in failed_addresses if not f.get(
+                        'nominatim_success', False)]
                     if final_failed:
                         failed_df = pandas.DataFrame(final_failed)
                         failed_file = self.output_folder / f"failed_{file.stem}.csv"
                         failed_df.to_csv(failed_file, index=False)
                         print(f"✔ Failed records: {failed_file}")
-                        
+
                 except Exception as e:
                     print(f"⚠ Save error: {e}")
                     success = False
-                    
+
             except Exception as e:
                 print(f"⚠ Error processing {file.name}: {e}")
                 success = False
-        
+
         return success
-    
+
     def _try_nominatim_geocoding(self, failed_addresses: list, geocode_results: list) -> int:
         """Try geocoding failed addresses using Nominatim fallback."""
         rescued = 0
-        
+
         for i, addr in enumerate(failed_addresses):
             try:
                 # Build query
                 parts = [str(addr['Address']).strip()]
                 if pandas.notna(addr.get('ZIP')):
                     parts.append(str(addr['ZIP']).strip())
-                
+
                 query = ", ".join(p for p in parts if p and p.lower() not in ['nan', 'none'])
                 if not query:
                     continue
-                
+
                 # Request with rate limiting
                 time.sleep(1)
                 params = {'q': query, 'format': 'json', 'limit': 1}
                 headers = {'User-Agent': 'GeocoderETL/1.0'}
-                
-                response = requests.get(self.nominatim_url, params=params, headers=headers, timeout=10)
-                
+
+                response = requests.get(self.nominatim_url, params=params,
+                                        headers=headers, timeout=10)
+
                 if response.status_code == 200:
                     data = response.json()
                     if data and isinstance(data, list) and len(data) > 0:
@@ -201,12 +206,12 @@ class GeocoderETL:
                                     if r['index'] == orig_idx:
                                         r['geometry'] = Point(lon, lat)
                                         break
-                                
+
                                 addr['nominatim_success'] = True
                                 rescued += 1
                         except:
                             pass
             except:
                 pass
-        
+
         return rescued

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,10 +6,11 @@
   "scripts": {
     "dev": "npm run beforestart && vite",
     "build": "npm run beforestart && tsc -b && vite build",
-    "build:gispreview": "NODE_ENV=development npm run build",
+    "build:gispreview": "NODE_ENV=development npm run build && npm run zipdist",
     "beforestart": "node beforeStart.js",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "zipdist": "tar --create --use-compress-program=pigz --file dist.tar.gz dist && rm -rf dist && mkdir dist && mv dist.tar.gz dist/"
   },
   "dependencies": {
     "@arcgis/map-components": "^4.33.2",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import {
   TAB_5_FRAGMENT,
 } from './components/navigation';
 import { AppDataContext, AppDataHookParameters, createAppDataContext } from './hooks/useAppData';
+import { notEmpty } from './utils';
 import {
   DevModeComponentsAll,
   EssentialServicesAccess,
@@ -39,11 +40,19 @@ export default function App() {
   const seasons = useMemo(() => {
     const seasons = (searchParams.get('seasons')?.split(',') || [])
       .map((str) => {
-        return str
+        const parts = str
           .trim()
           .split(':')
           .map((v) => v.trim());
+
+        if (parts.length !== 2) {
+          console.warn(`Invalid season format: ${str}. Expected format is 'Q2:2020'`);
+          return undefined;
+        }
+
+        return parts as [string, string];
       })
+      .filter(notEmpty)
       .map(([quarter, year]) => [quarter, parseInt(year)] as const)
       .filter((v): v is ['Q2' | 'Q4', number] => {
         const quarter = v[0];

--- a/frontend/src/components/common/Select/SelectOne.tsx
+++ b/frontend/src/components/common/Select/SelectOne.tsx
@@ -27,7 +27,9 @@ export function SelectOne({
 }: SelectOneProps) {
   function handleSelectionChange(evt: React.ChangeEvent<HTMLSelectElement>) {
     const newSelected = Array.from(evt.target.selectedOptions, (option) => option.value)[0];
-    onChange(newSelected);
+    if (newSelected) {
+      onChange(newSelected);
+    }
   }
 
   return (

--- a/frontend/src/components/options/areas/SelectedArea.tsx
+++ b/frontend/src/components/options/areas/SelectedArea.tsx
@@ -41,7 +41,11 @@ export function SelectedArea({ areasList }: SelectedAreaProps) {
           showId={false}
         />
       ) : (
-        <SelectOne onChange={handleChange} options={areasList} value={currentSelectedAreas[0]} />
+        <SelectOne
+          onChange={handleChange}
+          options={areasList}
+          value={currentSelectedAreas[0] || ''}
+        />
       )}
     </div>
   );

--- a/frontend/src/components/options/seasons/SelectedSeason.tsx
+++ b/frontend/src/components/options/seasons/SelectedSeason.tsx
@@ -56,7 +56,11 @@ export function SelectedSeason({ seasonsList }: SelectedSeasonProps) {
       {isComparing ? (
         <SelectMany options={options} onChange={handleChange} selectedOptions={selectedOptions} />
       ) : (
-        <SelectOne onChange={handleChange} options={options} value={selectedOptions[0]?.value} />
+        <SelectOne
+          onChange={handleChange}
+          options={options}
+          value={selectedOptions[0]?.value || ''}
+        />
       )}
     </div>
   );

--- a/frontend/src/data.d.ts
+++ b/frontend/src/data.d.ts
@@ -295,3 +295,34 @@ interface ServiceCoverage {
   paratransit_service_area_perimeter_meters: number;
   paratransit_service_area_area_square_meters: number;
 }
+
+interface EssentialServicesAccessStatistic {
+  area: string;
+  season: string;
+}
+
+interface EssentialServicesTripAccessStatistic extends EssentialServicesAccessStatistic {
+  replica_table: 'thursday_trip' | 'saturday_trip';
+  child_care__mean_travel_time?: number;
+  commercial_zone__mean_travel_time?: number;
+  healthcare__mean_travel_time?: number;
+  grocery_store__mean_travel_time?: number;
+}
+
+interface EssentialServicesPopulationAccessStatistic extends EssentialServicesAccessStatistic {
+  replica_table: 'population';
+  child_care__access_fraction?: number;
+  commercial_zone__access_fraction?: number;
+  healthcare__access_fraction?: number;
+  grocery_store__access_fraction?: number;
+}
+
+type EssentialServicesAccessStats =
+  | EssentialServicesTripAccessStatistic
+  | EssentialServicesPopulationAccessStatistic;
+
+type MergedEssentialServicesAccessStats = Omit<
+  EssentialServicesTripAccessStatistic,
+  'replica_table'
+> &
+  Omit<EssentialServicesPopulationAccessStatistic, 'replica_table'>;

--- a/frontend/src/hooks/useAppData.ts
+++ b/frontend/src/hooks/useAppData.ts
@@ -420,7 +420,7 @@ function getEssentialServicesPromises(
             fetchData<GeoJSON<{ ZONING: string }>>(
               `${essentialServicesFolder}/commercial_zone.geojson.deflate`,
               abortSignal
-            ).catch(handleError('commericial_zone_locations', true, true)),
+            ).catch(handleError('commercial_zone_locations', true, true)),
         },
       };
     });

--- a/frontend/src/hooks/useMapData.tsx
+++ b/frontend/src/hooks/useMapData.tsx
@@ -184,7 +184,7 @@ export function useMapData(data: AppData) {
                   outFields: ['*'],
                   creator: (event) => {
                     const stopRidership = Object.entries(
-                      selectedAreasAndSeasonsRidership[event?.graphic.attributes.ID]
+                      selectedAreasAndSeasonsRidership[event?.graphic.attributes.ID] || {}
                     ).map(([season, ridership]) => {
                       return [
                         season,
@@ -321,16 +321,14 @@ export function useMapData(data: AppData) {
               content: [
                 new FieldsContent({
                   title: 'Grocery Store Details',
-                  fieldInfos: Object.keys(grocery_store_locations.features[0].properties).map(
-                    (fieldName) => {
-                      return {
-                        fieldName,
-                        label: fieldName
-                          .replace(/_/g, ' ')
-                          .replace(/\b\w/g, (c) => c.toUpperCase()),
-                      };
-                    }
-                  ),
+                  fieldInfos: Object.keys(
+                    grocery_store_locations.features[0]?.properties || {}
+                  ).map((fieldName) => {
+                    return {
+                      fieldName,
+                      label: fieldName.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase()),
+                    };
+                  }),
                 }),
               ],
             }),
@@ -358,7 +356,7 @@ export function useMapData(data: AppData) {
               content: [
                 new FieldsContent({
                   title: 'Healthcare Facility Details',
-                  fieldInfos: Object.keys(healthcare_locations.features[0].properties).map(
+                  fieldInfos: Object.keys(healthcare_locations.features[0]?.properties || {}).map(
                     (fieldName) => {
                       return {
                         fieldName,
@@ -418,7 +416,7 @@ export function useMapData(data: AppData) {
               content: [
                 new FieldsContent({
                   title: 'Child Care Center Details',
-                  fieldInfos: Object.keys(child_care_locations.features[0].properties).map(
+                  fieldInfos: Object.keys(child_care_locations.features[0]?.properties || {}).map(
                     (fieldName) => {
                       return {
                         fieldName,
@@ -464,16 +462,14 @@ export function useMapData(data: AppData) {
               content: [
                 new FieldsContent({
                   title: 'Commercial Zone Details',
-                  fieldInfos: Object.keys(commercial_zone_locations.features[0].properties).map(
-                    (fieldName) => {
-                      return {
-                        fieldName,
-                        label: fieldName
-                          .replace(/_/g, ' ')
-                          .replace(/\b\w/g, (c) => c.toUpperCase()),
-                      };
-                    }
-                  ),
+                  fieldInfos: Object.keys(
+                    commercial_zone_locations.features[0]?.properties || {}
+                  ).map((fieldName) => {
+                    return {
+                      fieldName,
+                      label: fieldName.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase()),
+                    };
+                  }),
                 }),
               ],
             }),

--- a/frontend/src/hooks/useMapData.tsx
+++ b/frontend/src/hooks/useMapData.tsx
@@ -1,8 +1,10 @@
+import Color from '@arcgis/core/Color';
 import VectorTileLayer from '@arcgis/core/layers/VectorTileLayer.js';
-import { CustomContent } from '@arcgis/core/popup/content';
+import { CustomContent, FieldsContent } from '@arcgis/core/popup/content';
 import PopupTemplate from '@arcgis/core/PopupTemplate.js';
 import { SimpleRenderer } from '@arcgis/core/renderers';
-import { SimpleFillSymbol } from '@arcgis/core/symbols';
+import SizeVariable from '@arcgis/core/renderers/visualVariables/SizeVariable';
+import { SimpleFillSymbol, SimpleLineSymbol, SimpleMarkerSymbol } from '@arcgis/core/symbols';
 import { useMemo } from 'react';
 import { createRoot } from 'react-dom/client';
 import { useAppData } from '.';
@@ -149,6 +151,13 @@ export function useMapData(data: AppData) {
             title: `Routes (${__year} ${__quarter})`,
             id: `routes__${__year}_${__quarter}`,
             data: routes,
+            renderer: new SimpleRenderer({
+              symbol: new SimpleLineSymbol({
+                color: new Color([220, 119, 24, 1]),
+                width: 2,
+                style: 'solid',
+              }),
+            }),
           } satisfies GeoJSONLayerInit;
         })[0]
     );
@@ -271,6 +280,208 @@ export function useMapData(data: AppData) {
     );
   }, [data]);
 
+  const groceryStores = useMemo(() => {
+    return (
+      (data || [])
+        .filter(notEmpty)
+        .filter(requireKey('grocery_store_locations'))
+        // only keep the first occurrence because it would be confusing to show grocery stores on top of each other over time
+        .slice(0, 1)
+        .map(({ grocery_store_locations, __quarter, __year }) => {
+          return {
+            title: `Grocery Stores (${__year} ${__quarter})`,
+            id: `grocery-stores__${__year}_${__quarter}`,
+            data: grocery_store_locations,
+            renderer: new SimpleRenderer({
+              symbol: new SimpleMarkerSymbol({
+                angle: 60,
+                color: new Color([71, 245, 170, 1]),
+                outline: new SimpleLineSymbol({
+                  color: new Color([39, 98, 84, 1]),
+                  style: 'solid',
+                  width: 1,
+                }),
+                style: 'triangle',
+              }),
+              visualVariables: [
+                new SizeVariable({
+                  valueExpression: '$view.scale',
+                  stops: [
+                    { size: 2, value: 360000 },
+                    { size: 4, value: 240000 },
+                    { size: 12, value: 12000 },
+                    { size: 20, value: 0 },
+                  ],
+                }),
+              ],
+            }),
+            popupEnabled: true,
+            popupTemplate: new PopupTemplate({
+              title: `{Company Name} (${__year} ${__quarter})`,
+              content: [
+                new FieldsContent({
+                  title: 'Grocery Store Details',
+                  fieldInfos: Object.keys(grocery_store_locations.features[0].properties).map(
+                    (fieldName) => {
+                      return {
+                        fieldName,
+                        label: fieldName
+                          .replace(/_/g, ' ')
+                          .replace(/\b\w/g, (c) => c.toUpperCase()),
+                      };
+                    }
+                  ),
+                }),
+              ],
+            }),
+          } satisfies GeoJSONLayerInit;
+        })[0]
+    );
+  }, [data]);
+
+  const healthcareFacilities = useMemo(() => {
+    return (
+      (data || [])
+        .filter(notEmpty)
+        .filter(requireKey('healthcare_locations'))
+        // only keep the first occurrence because it would be confusing to show healthcare facilities on top of each other over time
+        .slice(0, 1)
+        .map(({ healthcare_locations, __quarter, __year }) => {
+          return {
+            title: `Healthcare Facilities (${__year} ${__quarter})`,
+            id: `healthcare-facilities__${__year}_${__quarter}`,
+            data: healthcare_locations,
+            popupEnabled: true,
+            // TODO: add a facy renderer with a medical symbol
+            popupTemplate: new PopupTemplate({
+              title: `{Name} (${__year} ${__quarter})`,
+              content: [
+                new FieldsContent({
+                  title: 'Healthcare Facility Details',
+                  fieldInfos: Object.keys(healthcare_locations.features[0].properties).map(
+                    (fieldName) => {
+                      return {
+                        fieldName,
+                        label: fieldName
+                          .replace(/_/g, ' ')
+                          .replace(/\b\w/g, (c) => c.toUpperCase()),
+                      };
+                    }
+                  ),
+                }),
+              ],
+            }),
+          } satisfies GeoJSONLayerInit;
+        })[0]
+    );
+  }, [data]);
+
+  const childCareCenters = useMemo(() => {
+    return (
+      (data || [])
+        .filter(notEmpty)
+        .filter(requireKey('child_care_locations'))
+        // only keep the first occurrence because it would be confusing to show child care centers on top of each other over time
+        .slice(0, 1)
+        .map(({ child_care_locations, __quarter, __year }) => {
+          return {
+            title: `Child Care Centers (${__year} ${__quarter})`,
+            id: `child-care-centers__${__year}_${__quarter}`,
+            data: child_care_locations,
+            renderer: new SimpleRenderer({
+              symbol: new SimpleMarkerSymbol({
+                angle: 0,
+                color: new Color([71, 100, 245, 1]),
+                outline: new SimpleLineSymbol({
+                  color: new Color([0, 47, 189, 1]),
+                  style: 'solid',
+                  width: 1,
+                }),
+                size: 8,
+                style: 'diamond',
+              }),
+              visualVariables: [
+                new SizeVariable({
+                  valueExpression: '$view.scale',
+                  stops: [
+                    { size: 2, value: 360000 },
+                    { size: 4, value: 240000 },
+                    { size: 12, value: 12000 },
+                    { size: 20, value: 0 },
+                  ],
+                }),
+              ],
+            }),
+            popupEnabled: true,
+            popupTemplate: new PopupTemplate({
+              title: `{Provider Name} (${__year} ${__quarter})`,
+              content: [
+                new FieldsContent({
+                  title: 'Child Care Center Details',
+                  fieldInfos: Object.keys(child_care_locations.features[0].properties).map(
+                    (fieldName) => {
+                      return {
+                        fieldName,
+                        label: fieldName
+                          .replace(/_/g, ' ')
+                          .replace(/\b\w/g, (c) => c.toUpperCase()),
+                      };
+                    }
+                  ),
+                }),
+              ],
+            }),
+            // renderer: createInterestAreaRenderer(),
+          } satisfies GeoJSONLayerInit;
+        })[0]
+    );
+  }, [data]);
+
+  const commercialZones = useMemo(() => {
+    return (
+      (data || [])
+        .filter(notEmpty)
+        .filter(requireKey('commercial_zone_locations'))
+        // only keep the first occurrence because it would be confusing to show commercial zones on top of each other over time
+        .slice(0, 1)
+        .map(({ commercial_zone_locations, __quarter, __year }) => {
+          return {
+            title: `Commercial Zones (${__year} ${__quarter})`,
+            id: `commercial-zones__${__year}_${__quarter}`,
+            data: commercial_zone_locations,
+            renderer: new SimpleRenderer({
+              symbol: new SimpleFillSymbol({
+                color: [255, 0, 255, 0.18],
+                outline: {
+                  color: [0, 0, 0, 0],
+                  width: 0,
+                },
+              }),
+            }),
+            popupEnabled: true,
+            popupTemplate: new PopupTemplate({
+              title: `{Name} (${__year} ${__quarter})`,
+              content: [
+                new FieldsContent({
+                  title: 'Commercial Zone Details',
+                  fieldInfos: Object.keys(commercial_zone_locations.features[0].properties).map(
+                    (fieldName) => {
+                      return {
+                        fieldName,
+                        label: fieldName
+                          .replace(/_/g, ' ')
+                          .replace(/\b\w/g, (c) => c.toUpperCase()),
+                      };
+                    }
+                  ),
+                }),
+              ],
+            }),
+          } satisfies GeoJSONLayerInit;
+        })[0]
+    );
+  }, [data]);
+
   return {
     networkSegments,
     areaPolygons,
@@ -279,6 +490,10 @@ export function useMapData(data: AppData) {
     walkServiceAreas,
     cyclingServiceAreas,
     paratransitServiceAreas,
+    groceryStores,
+    healthcareFacilities,
+    childCareCenters,
+    commercialZones,
   };
 }
 

--- a/frontend/src/views/EssentialServicesAccess.tsx
+++ b/frontend/src/views/EssentialServicesAccess.tsx
@@ -60,7 +60,7 @@ function Sections() {
         label="Grocery Stores"
         wrap
         data={data?.map((area) => {
-          const stat = area.essential_services_access_stats?.grocery_store__access_fraction || NaN;
+          const stat = area.essential_services_access_stats?.grocery_store__access_fraction ?? NaN;
           return { label: area.__label, value: (stat * 100).toFixed(1) };
         })}
       />
@@ -68,7 +68,7 @@ function Sections() {
         label="Healthcare"
         wrap
         data={data?.map((area) => {
-          const stat = area.essential_services_access_stats?.healthcare__access_fraction || NaN;
+          const stat = area.essential_services_access_stats?.healthcare__access_fraction ?? NaN;
           return { label: area.__label, value: (stat * 100).toFixed(1) };
         })}
       />
@@ -76,7 +76,7 @@ function Sections() {
         label="Child Care Centers"
         wrap
         data={data?.map((area) => {
-          const stat = area.essential_services_access_stats?.child_care__access_fraction || NaN;
+          const stat = area.essential_services_access_stats?.child_care__access_fraction ?? NaN;
           return { label: area.__label, value: (stat * 100).toFixed(1) };
         })}
       />
@@ -85,7 +85,7 @@ function Sections() {
         wrap
         data={data?.map((area) => {
           const stat =
-            area.essential_services_access_stats?.commercial_zone__access_fraction || NaN;
+            area.essential_services_access_stats?.commercial_zone__access_fraction ?? NaN;
           return { label: area.__label, value: (stat * 100).toFixed(1) };
         })}
       />
@@ -95,7 +95,7 @@ function Sections() {
         label="Grocery Stores"
         wrap
         data={data?.map((area) => {
-          const stat = area.essential_services_access_stats?.grocery_store__mean_travel_time || NaN;
+          const stat = area.essential_services_access_stats?.grocery_store__mean_travel_time ?? NaN;
           return { label: area.__label, value: stat.toFixed(1) };
         })}
         unit="minutes"
@@ -104,7 +104,7 @@ function Sections() {
         label="Healthcare"
         wrap
         data={data?.map((area) => {
-          const stat = area.essential_services_access_stats?.healthcare__mean_travel_time || NaN;
+          const stat = area.essential_services_access_stats?.healthcare__mean_travel_time ?? NaN;
           return { label: area.__label, value: stat.toFixed(1) };
         })}
         unit="minutes"
@@ -113,7 +113,7 @@ function Sections() {
         label="Child Care Centers"
         wrap
         data={data?.map((area) => {
-          const stat = area.essential_services_access_stats?.child_care__mean_travel_time || NaN;
+          const stat = area.essential_services_access_stats?.child_care__mean_travel_time ?? NaN;
           return { label: area.__label, value: stat.toFixed(1) };
         })}
         unit="minutes"
@@ -123,7 +123,7 @@ function Sections() {
         wrap
         data={data?.map((area) => {
           const stat =
-            area.essential_services_access_stats?.commercial_zone__mean_travel_time || NaN;
+            area.essential_services_access_stats?.commercial_zone__mean_travel_time ?? NaN;
           return { label: area.__label, value: stat.toFixed(1) };
         })}
         unit="minutes"

--- a/frontend/src/views/EssentialServicesAccess.tsx
+++ b/frontend/src/views/EssentialServicesAccess.tsx
@@ -1,17 +1,152 @@
 import '@arcgis/map-components/dist/components/arcgis-map';
-import { CoreFrame } from '../components';
+import { CoreFrame, Map, Section, SidebarContent, Statistic } from '../components';
 import { AppNavigation } from '../components/navigation';
+import {
+  ComparisonModeSwitch,
+  SelectedArea,
+  SelectedSeason,
+  SelectTravelMethod,
+} from '../components/options';
+import { useAppData, useMapData } from '../hooks';
 
 export function EssentialServicesAccess() {
+  const { data } = useAppData();
+  const {
+    networkSegments,
+    areaPolygons,
+    routes,
+    stops,
+    walkServiceAreas,
+    groceryStores,
+    healthcareFacilities,
+    childCareCenters,
+    commercialZones,
+  } = useMapData(data);
+
   return (
     <CoreFrame
       outerStyle={{ height: '100%' }}
       header={<AppNavigation />}
+      sidebar={<Sidebar />}
       map={
         <div style={{ height: '100%' }}>
-          <arcgis-map basemap="topo-vector" zoom={12} center="-82.4, 34.85"></arcgis-map>
+          <Map
+            layers={[
+              ...networkSegments,
+              walkServiceAreas,
+              routes,
+              stops,
+              groceryStores,
+              healthcareFacilities,
+              childCareCenters,
+              commercialZones,
+              ...areaPolygons,
+            ]}
+          />
         </div>
       }
+      sections={Sections()}
     />
+  );
+}
+
+function Sections() {
+  const { data } = useAppData();
+
+  return [
+    <Section title="Essential Services Access via Public Transit">
+      <Statistic.Percent
+        label="Grocery Stores"
+        wrap
+        data={data?.map((area) => {
+          const stat = area.essential_services_access_stats?.grocery_store__access_fraction || NaN;
+          return { label: area.__label, value: (stat * 100).toFixed(1) };
+        })}
+      />
+      <Statistic.Percent
+        label="Healthcare"
+        wrap
+        data={data?.map((area) => {
+          const stat = area.essential_services_access_stats?.healthcare__access_fraction || NaN;
+          return { label: area.__label, value: (stat * 100).toFixed(1) };
+        })}
+      />
+      <Statistic.Percent
+        label="Child Care Centers"
+        wrap
+        data={data?.map((area) => {
+          const stat = area.essential_services_access_stats?.child_care__access_fraction || NaN;
+          return { label: area.__label, value: (stat * 100).toFixed(1) };
+        })}
+      />
+      <Statistic.Percent
+        label="Commerical Zones"
+        wrap
+        data={data?.map((area) => {
+          const stat =
+            area.essential_services_access_stats?.commercial_zone__access_fraction || NaN;
+          return { label: area.__label, value: (stat * 100).toFixed(1) };
+        })}
+      />
+    </Section>,
+    <Section title="Recorded Average Travel Time to Essential Services via Public Transit">
+      <Statistic.Number
+        label="Grocery Stores"
+        wrap
+        data={data?.map((area) => {
+          const stat = area.essential_services_access_stats?.grocery_store__mean_travel_time || NaN;
+          return { label: area.__label, value: stat.toFixed(1) };
+        })}
+        unit="minutes"
+      />
+      <Statistic.Number
+        label="Healthcare"
+        wrap
+        data={data?.map((area) => {
+          const stat = area.essential_services_access_stats?.healthcare__mean_travel_time || NaN;
+          return { label: area.__label, value: stat.toFixed(1) };
+        })}
+        unit="minutes"
+      />
+      <Statistic.Number
+        label="Child Care Centers"
+        wrap
+        data={data?.map((area) => {
+          const stat = area.essential_services_access_stats?.child_care__mean_travel_time || NaN;
+          return { label: area.__label, value: stat.toFixed(1) };
+        })}
+        unit="minutes"
+      />
+      <Statistic.Number
+        label="Commerical Zones"
+        wrap
+        data={data?.map((area) => {
+          const stat =
+            area.essential_services_access_stats?.commercial_zone__mean_travel_time || NaN;
+          return { label: area.__label, value: stat.toFixed(1) };
+        })}
+        unit="minutes"
+      />
+    </Section>,
+  ];
+}
+
+function Sidebar() {
+  const { areasList, seasonsList, travelMethodList } = useAppData();
+
+  return (
+    <SidebarContent>
+      <h1>Options</h1>
+
+      <h2>Filters</h2>
+      <SelectedArea areasList={areasList} />
+      <SelectedSeason seasonsList={seasonsList} />
+
+      <h2>Compare</h2>
+      <ComparisonModeSwitch />
+
+      <h2>Travel Density Segments</h2>
+      <SelectTravelMethod travelMethodList={travelMethodList} />
+    </SidebarContent>
   );
 }

--- a/frontend/src/views/EssentialServicesAccess.tsx
+++ b/frontend/src/views/EssentialServicesAccess.tsx
@@ -80,7 +80,7 @@ function Sections() {
         })}
       />
       <Statistic.Percent
-        label="Commerical Zones"
+        label="Commercial Zones"
         wrap
         data={data?.map((area) => {
           const stat =
@@ -118,7 +118,7 @@ function Sections() {
         unit="minutes"
       />
       <Statistic.Number
-        label="Commerical Zones"
+        label="Commercial Zones"
         wrap
         data={data?.map((area) => {
           const stat =

--- a/frontend/src/views/EssentialServicesAccess.tsx
+++ b/frontend/src/views/EssentialServicesAccess.tsx
@@ -8,6 +8,7 @@ import {
   SelectTravelMethod,
 } from '../components/options';
 import { useAppData, useMapData } from '../hooks';
+import { notEmpty } from '../utils';
 
 export function EssentialServicesAccess() {
   const { data } = useAppData();
@@ -41,7 +42,7 @@ export function EssentialServicesAccess() {
               childCareCenters,
               commercialZones,
               ...areaPolygons,
-            ]}
+            ].filter(notEmpty)}
           />
         </div>
       }

--- a/frontend/src/views/GeneralAccess.tsx
+++ b/frontend/src/views/GeneralAccess.tsx
@@ -48,7 +48,7 @@ export function GeneralAccess() {
               routes,
               stops,
               ...areaPolygons,
-            ]}
+            ].filter(notEmpty)}
           />
         </div>
       }
@@ -172,7 +172,7 @@ function Sections() {
         label="Population total"
         data={data?.map((area) => ({
           label: area.__label,
-          value: area.population_total?.[0].population__total || 0,
+          value: area.population_total?.[0]?.population__total || 0,
         }))}
       />
       <SectionEntry>

--- a/frontend/src/views/RoadsVsTransit.tsx
+++ b/frontend/src/views/RoadsVsTransit.tsx
@@ -264,7 +264,7 @@ function Comparison() {
           className="selected-scenario"
           options={['Scenario 1', 'Scenario 2', 'Scenario 3', 'Scenario 4']}
           onChange={(value) => {
-            const index = parseInt(value.split(' ')[1], 10) - 1;
+            const index = parseInt(value.split(' ')[1] || '-', 10) - 1;
             switchSelectedIndex(index);
           }}
           value={selectedIndex !== null ? `Scenario ${selectedIndex + 1}` : ''}

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -22,7 +22,8 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+    "noUncheckedIndexedAccess": true
   },
   "include": [
     "src"


### PR DESCRIPTION
This PR adds the following essential services data:

- percent access to healthcare via public transit
- percent access to grocery stores via public transit
- percent access to child care centers via public transit
- percent access to commercial zones
- measured mean travel time to healthcare locations
- measured mean travel time to grocery stores
- measured mean travel time to child care centers
- measured mean travel time to commercial zones

Healthcare data, grocery store data, and child care center data are read from the output of the geocoder etl. They should be provided to the goeocder in the `input/to_geocode` folder with the following name formats:

| Dataset | File name |
| --- | --- |
| healthcare | healthcare__YYYY-MM-DD |
| childcare | childcare__YYYY-MM-DD |
| grocery stores | grocery_stores__YYYY-MM-DD |

Greenville County zoning data should be provided in shapefile format (which is how the county provides it) in `input/zoning/<ISO-8601 date>`, where each folder is named with an ISO-8601 date (not datetime) with the shapefile inside. It needs all extensions, not just .shp.

The essential services ETL will attempt to use the closest available data for each season. For example, if there is healthcare data for 2023-04-21 and 2025-01-19, it will use the 2023-04-21 data for 2023 Q4 and the 2025-01-19 data for 2024 Q4.

Statistics in the form of access fractions and travel times are output to a JSON file at `data/essential_services/essential_services_stats.json`. The geospatial data files are output in geojson format in `data/essential_services/<year>/<quarter>/<child_care | healthcare | commercial_zone | grocery_store>.geojson` for easy use on the frontend. Additional geospatial are included for each area for each season for exploratory use as well.

**Determining travel time related to a destination**
400-m (~0.25mi) geodesic buffers are drawn around the input geometry, and then all trips via public transit that end within those buffers are used for calculating the mean travel time to that location.

**Determining access**
Buffers are drawn around the service geometry. Then, the buffers are clipped to the walkshed geometry. Finally, the sythentic population (home locations) are summed. A fraction representing what proportion of the synthetic population in lives in the buffer is calculated.

| Dataset | Buffer size | Note |
| --- | --- | --- |
| healthcare | 3 mi | most definitions use a mixture of wait times, travel times, and geographic access. I used 3 mi |
| childcare | 3 mi | most definitions related to access with a tract, so 3 mi seems generous |
| grocery stores | 1 mi | USDA definition of food desert is > 1 from a grocery store |

On the frontend, the statistics are shown in the sections area and the geospatial data are shown on the web map. Child care centers are teal triangles, grocery stores are blue angled squares, and commerical areas are 82% transparent dark pink polygons.

<img width="2208" height="1062" alt="image" src="https://github.com/user-attachments/assets/1fa517b1-e1a4-41fe-b641-5a4e51734efd" />
