### PR TITLE
feat(frontend): add `Figure` statistic component

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "@observablehq/plot": "^0.6.17",
         "@types/mapbox-gl": "^3.4.1",
         "groupby-polyfill": "^1.0.0",
+        "htl": "^0.3.1",
         "pako": "^2.1.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -4287,6 +4288,15 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/htl": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/htl/-/htl-0.3.1.tgz",
+      "integrity": "sha512-1LBtd+XhSc+++jpOOt0lCcEycXs/zTQSupOISnVAUmvGBpV7DH+C2M6hwV7zWYfpTMMg9ch4NO0lHiOTAMHdVA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/iconv-lite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "@observablehq/plot": "^0.6.17",
     "@types/mapbox-gl": "^3.4.1",
     "groupby-polyfill": "^1.0.0",
+    "htl": "^0.3.1",
     "pako": "^2.1.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/frontend/src/components/common/Section/SectionEntry.tsx
+++ b/frontend/src/components/common/Section/SectionEntry.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-interface SectionEntryProps {
+export interface SectionEntryProps {
   /** The component or element to be rendered inside this entry */
   children: React.ReactElement;
   /** Whether this section entry will be hidden from the section. Hiding an entry may cause other entries to be repositioned. */

--- a/frontend/src/components/common/Statistic/Figure.tsx
+++ b/frontend/src/components/common/Statistic/Figure.tsx
@@ -1,0 +1,87 @@
+import styled from '@emotion/styled';
+import { SectionEntry, SectionEntryProps } from '../Section/SectionEntry';
+import { PlotContainer, PlotFigureProps } from './plot/PlotContainer';
+import { StatisticContainer as _StatisticContainer } from './StatisticContainer';
+
+export interface FigureProps {
+  /** The label of the figure */
+  label: string;
+  /** The optional SVG icon to show in front of the label */
+  icon?: React.ReactElement<SVGSVGElement>;
+  /** The figure to show. */
+  plot: PlotFigureProps['options'] | PlotFigureProps['options'][];
+  /** If true or an object, the statisitic container will be wrapped in a `<SectionEntry>` Objects should be of tye `SectionEntryProps`. */
+  wrap?: boolean | Omit<SectionEntryProps, 'children'>;
+  /** Show the legend swatches before the plot title */
+  legendBeforeTitle?: boolean;
+}
+
+export function Figure(props: FigureProps) {
+  const content = (
+    <StatisticContainer legendBeforeTitle={props.legendBeforeTitle}>
+      {props.icon}
+      <div className="content">
+        <div className="label">{props.label}</div>
+        {Array.isArray(props.plot) ? (
+          props.plot.map((plot, index) => {
+            return (
+              <>
+                <PlotContainer
+                  options={plot}
+                  key={index}
+                  className="plot-container"
+                  titleTag="h4"
+                />
+              </>
+            );
+          })
+        ) : (
+          <PlotContainer options={props.plot} titleTag="h4" />
+        )}
+      </div>
+    </StatisticContainer>
+  );
+
+  if (props.wrap) {
+    let sectionEntryProps: SectionEntryProps = {
+      children: content,
+    };
+
+    if (typeof props.wrap === 'object') {
+      sectionEntryProps = {
+        ...sectionEntryProps,
+        ...props.wrap,
+      };
+    }
+
+    return <SectionEntry {...sectionEntryProps} />;
+  }
+
+  return content;
+}
+
+const StatisticContainer = styled(_StatisticContainer)<{ legendBeforeTitle?: boolean }>`
+  & > .content {
+    width: 100%;
+
+    h4.plot-title {
+      font-size: 0.875rem;
+      font-weight: 400;
+      margin: 0;
+    }
+
+    .plot-container + .plot-container {
+      margin-top: 0.75rem;
+    }
+
+    ${({ legendBeforeTitle }) => {
+      if (legendBeforeTitle) {
+        return `
+          div[class^='plot-'][class*='-swatches'] {
+            grid-row: 1;
+          }
+        `;
+      }
+    }}
+  }
+`;

--- a/frontend/src/components/common/Statistic/index.ts
+++ b/frontend/src/components/common/Statistic/index.ts
@@ -1,9 +1,11 @@
+import { Figure } from './Figure';
 import { Number } from './Number';
 import { Percent } from './Percent';
 
 const Statistic = {
   Number,
   Percent,
+  Figure,
 };
 
 export { Statistic };

--- a/frontend/src/components/common/Statistic/plot/PlotContainer.tsx
+++ b/frontend/src/components/common/Statistic/plot/PlotContainer.tsx
@@ -1,0 +1,123 @@
+import styled from '@emotion/styled';
+import * as Plot from '@observablehq/plot';
+import * as d3 from 'd3';
+import { useEffect, useRef } from 'react';
+import { useRect } from '../../../../hooks';
+import { facetedHorizontalBar } from './presets/facetedHorizontalBar';
+import { horizontalBar } from './presets/hoizontalBar';
+
+export interface PlotFigureProps {
+  options:
+    | Plot.PlotOptions
+    | ((plotLib: typeof Plot, d3Lib: typeof d3, helpers: Helpers) => Plot.PlotOptions);
+  className?: string;
+  titleTag?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+}
+
+export function PlotContainer(props: PlotFigureProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const { width } = useRect(containerRef);
+
+  useEffect(() => {
+    if (containerRef.current == null) {
+      return;
+    }
+
+    const options =
+      typeof props.options === 'function' ? props.options(Plot, d3, helpers) : props.options;
+    if (options == null) {
+      return;
+    }
+
+    if (!options.width) {
+      options.width = width || 640;
+    }
+
+    if (options.title && typeof options.title === 'string') {
+      const node = document.createElement(props.titleTag || 'h2');
+      node.classList.add('plot-title');
+      node.textContent = options.title;
+      options.title = node;
+    }
+
+    const plot = Plot.plot(options);
+    containerRef.current.append(plot);
+
+    return () => {
+      plot.remove();
+    };
+  }, [props.options, width]);
+
+  return <Container ref={containerRef} className={props.className} />;
+}
+
+const helpers = {
+  presets: {
+    facetedHorizontalBar,
+    horizontalBar,
+  },
+  utils: {
+    sumAcross: (data: Record<string, unknown>[], key: string) => {
+      return data.reduce((acc, d) => {
+        const value = d[key];
+        if (typeof value === 'number') {
+          return acc + value;
+        }
+        return acc;
+      }, 0);
+    },
+    maxAcross: (data: Record<string, unknown>[], key: string) => {
+      return data.reduce((acc, d) => {
+        const value = d[key];
+        if (typeof value === 'number') {
+          return Math.max(acc, value);
+        }
+        return acc;
+      }, -Infinity);
+    },
+  },
+};
+type Helpers = typeof helpers;
+
+const Container = styled.div`
+  width: 100%;
+
+  svg {
+    font-family: inherit;
+
+    g[aria-label*='-axis label'] {
+      font-size: 0.813rem;
+    }
+
+    g[aria-label*='-axis tick label'] {
+      font-size: 0.75rem;
+    }
+  }
+
+  figure {
+    margin: 0;
+    display: grid;
+    grid-template-columns: 1fr;
+    grid-auto-rows: auto;
+
+    div[class^='plot-'][class*='-swatches'] {
+      min-height: unset;
+      font-family: inherit;
+      font-size: 0.875rem;
+      gap: 0rem 0.5rem;
+      margin-bottom: 0.5rem;
+
+      span[class^='plot-'][class$='-swatch'] {
+        margin-right: 0;
+
+        svg rect {
+          rx: var(--button-radius);
+        }
+      }
+    }
+
+    figcaption {
+      font-size: 0.813rem;
+    }
+  }
+`;

--- a/frontend/src/components/common/Statistic/plot/presets/facetedHorizontalBar.ts
+++ b/frontend/src/components/common/Statistic/plot/presets/facetedHorizontalBar.ts
@@ -1,0 +1,100 @@
+import * as Plot from '@observablehq/plot';
+import * as d3 from 'd3';
+
+interface FacetedHorizontalBarParams {
+  domainY: string[];
+  data: Record<string, unknown>[];
+
+  axis: {
+    label: string;
+    tickFormat: (n: number) => string;
+    domainX?: [number, number];
+  };
+
+  /** The property to use for the x-axis */
+  x: string;
+  /** The property to use for the y-axis */
+  y: string;
+  /** The property to use for faceting */
+  fy: string;
+  /** The property to use for fill color. It can be a color code or another string. If a string, it should match domainY. If not specified, `y` will be used. */
+  fill?: string;
+
+  /** The gap for each facet. It is relative to the facet height. */
+  padding?: number;
+}
+
+export function facetedHorizontalBar(params: FacetedHorizontalBarParams) {
+  const facetNames = Array.from(new Set(params.data.map((d) => d[params.fy])));
+
+  return {
+    color: {
+      domain: params.domainY,
+    },
+    fy: {
+      // hide area/season axis label
+      label: null,
+      // gap between each facet
+      padding: params.padding ?? 0.3,
+      align: 1,
+    },
+    y: {
+      // hide the axis - the legend will suffice
+      axis: null,
+      domain: params.domainY,
+    },
+    x: {
+      grid: true,
+      tickSpacing: 50,
+      label: params.axis.label,
+      tickFormat: params.axis.tickFormat,
+      domain: params.axis.domainX,
+    },
+    marginLeft: 0,
+    marginTop: 28,
+    marginBottom: 40,
+    marks: [
+      Plot.barX(params.data, {
+        x: params.x,
+        y: params.y,
+        fy: params.fy,
+        fill: params.fill || params.y,
+        title: (d) => d[params.fy],
+        sort: { x: 'y' },
+        strokeWidth: 20,
+      }),
+
+      // line at the start of the bars
+      Plot.ruleX([0]),
+
+      // bar labels
+      Plot.text(params.data, {
+        x: params.x,
+        y: params.y,
+        fy: params.fy,
+        text: (d) => {
+          const showPercent = d[params.x] > 0.05;
+          return showPercent ? `${d3.format('.0%')(d[params.x])}` : '';
+        },
+        dx: -6,
+        textAnchor: 'end',
+        fill: 'white',
+        stroke: 'black',
+        strokeOpacity: 0.14,
+      }),
+
+      // place area/season labels at the top of each group of bars
+      Plot.text(facetNames, {
+        x: 0,
+        fy: (d) => d,
+        frameAnchor: 'top',
+        textAnchor: 'start',
+        text: (d) => d,
+        dy: -20,
+        dx: 0,
+        fontWeight: 400,
+        fontSize: 14,
+      }),
+    ],
+  };
+}

--- a/frontend/src/components/common/Statistic/plot/presets/hoizontalBar.ts
+++ b/frontend/src/components/common/Statistic/plot/presets/hoizontalBar.ts
@@ -1,0 +1,154 @@
+import * as Plot from '@observablehq/plot';
+import * as d3 from 'd3';
+
+interface HorizontalBarParams {
+  data: Record<string, unknown>[];
+
+  domainX?: [number, number];
+  domainY: string[];
+
+  axis: {
+    label: string;
+    tickFormat: (n: number) => string;
+  };
+
+  /** The property to use for the x-axis */
+  x: string;
+  /** The property to use for the y-axis */
+  y: string;
+  /** The property to use for fill color. It can be a color code or another string. If a string, it should match domainY. If not specified, `y` will be used. */
+  fill?: string;
+
+  /** The height of the horizontal bars. Defaults to 18px. */
+  barHeight?: number;
+  /** The gap between the horizontal bars. Defaults to 2px. */
+  barGap?: number;
+
+  /** The border radius to use on the end of the horizontal bars. */
+  borderRadius?: number;
+}
+
+/**
+ * Creates a horizontal bar plot based on rectangles. This allows the bar height and gap to be customized.
+ * @param params
+ * @returns
+ */
+export function horizontalBar(params: HorizontalBarParams) {
+  const barHeight = params.barHeight ?? 18;
+  const barGap = params.barGap ?? 2;
+  const borderRadius = params.borderRadius ?? 3;
+
+  // find the largest x value in the data
+  const dataMaxX = params.data
+    .map((d) => parseFloat(d[params.x] as string))
+    .reduce((a, b) => Math.max(a, b), 0);
+
+  const domainX = params.domainX || [0, dataMaxX];
+
+  const rectData = params.data
+    // filter to only allow values in domainY
+    .filter((d) => params.domainY.includes(d[params.y] as string))
+    // sort based on the order of domainY
+    .sort(
+      (a, b) =>
+        params.domainY.indexOf(b[params.y] as string) -
+        params.domainY.indexOf(a[params.y] as string)
+    )
+    // assign rectangle coordinates based on the data
+    .map((d, i) => {
+      return {
+        ...d,
+        x1: 0,
+        // clamp the x-value to not exceed the domain
+        x2: Math.min(parseFloat(d[params.x] as string), domainX[1]),
+        y1: i * (barHeight + barGap),
+        y2: i * (barHeight + barGap) + barHeight,
+      };
+    });
+
+  const marginTop = 0;
+  const marginBottom = params.axis.label ? 40 : 0;
+  const tickSize = 6;
+  const maxY = rectData.map((d) => d.y2).reduce((a, b) => Math.max(a, b), 0);
+
+  const addTickToStartY = domainX[0] === 0 ? tickSize : 0;
+  const addTickToEndY = true;
+  const numericalDomainY = [addTickToStartY ? -tickSize : 0, maxY + (addTickToEndY ? tickSize : 0)];
+
+  return {
+    color: {
+      domain: params.domainY,
+    },
+    y: {
+      // hide the axis - the legend will suffice
+      axis: null,
+      domain: numericalDomainY,
+    },
+    x: {
+      grid: true,
+      tickSpacing: 50,
+      label: params.axis.label || '',
+      tickFormat: params.axis.tickFormat,
+      labelArrow: !!params.axis.label,
+      tickSize,
+    },
+    marginLeft: 0,
+    marginTop,
+    marginBottom,
+    height:
+      rectData.length * barHeight +
+      (rectData.length - 1) * barGap +
+      marginTop +
+      marginBottom +
+      (addTickToStartY ? tickSize : 0) +
+      (addTickToEndY ? tickSize : 0),
+    marks: [
+      Plot.rect(rectData, {
+        fill: params.fill || params.y,
+        x1: 'x1',
+        x2: 'x2',
+        y1: 'y1',
+        y2: 'y2',
+        rx2: borderRadius,
+      }),
+
+      // line at the start of the bars
+      Plot.ruleX([0]),
+
+      // force x-axis to to go up to the max of domainX
+      Plot.ruleX([0, domainX[1]], { stroke: 'transparent' }),
+
+      // bar labels - inside
+      Plot.text(rectData, {
+        x: 'x2',
+        y: (d) => (d.y1 + d.y2) / 2,
+        text: (d) => {
+          const showPercent = d[params.x] > 0.05;
+          return showPercent ? `${d3.format('.0%')(d[params.x])}` : '';
+        },
+        dx: -6,
+        textAnchor: 'end',
+        fill: 'white',
+        stroke: 'black',
+        strokeOpacity: 0.14,
+        fontSize: 11,
+      }),
+
+      // bar labels - outside
+      Plot.text(rectData, {
+        x: 'x2',
+        y: (d) => (d.y1 + d.y2) / 2,
+        text: (d) => {
+          const showPercent = d[params.x] <= 0.05;
+          return showPercent ? `${d3.format('.0%')(d[params.x])}` : '';
+        },
+        dx: 6,
+        textAnchor: 'start',
+        fill: 'black',
+        stroke: 'white',
+        strokeOpacity: 0.14,
+        fontSize: 11,
+      }),
+    ],
+  } satisfies Plot.PlotOptions;
+}

--- a/frontend/src/components/common/index.ts
+++ b/frontend/src/components/common/index.ts
@@ -10,6 +10,7 @@ export { SelectMany } from './Select/SelectMany';
 export { SelectOne } from './Select/SelectOne';
 export { SidebarContent } from './SidebarContent/SidebarContent';
 export { Statistic } from './Statistic';
+export { PlotContainer } from './Statistic/plot/PlotContainer';
 export { Tab } from './Tabs/Tab';
 export { Tabs } from './Tabs/Tabs';
 export { TreeMap } from './TreeMap/TreeMap';

--- a/frontend/src/index.d.ts
+++ b/frontend/src/index.d.ts
@@ -1,0 +1,11 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+declare module 'htl' {
+  export const html: {
+    <T extends HTMLElement | Text>(...args: any[]): T;
+    fragment(...args: any[]): DocumentFragment;
+  };
+  export const svg: {
+    <T extends SVGElement | Text>(...args: any[]): T;
+    fragment(...args: any[]): DocumentFragment;
+  };
+}

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -5,4 +5,5 @@ export { inflateResponse } from './inflateResponse';
 export { notEmpty } from './notEmpty';
 export { quadraticBezierToPolygon } from './quadraticBezierToPolygon';
 export { requireKey } from './requireKey';
+export { toTidyNominal } from './toTidyNominal';
 export { withOpacity } from './withOpacity';

--- a/frontend/src/utils/toTidyNominal.ts
+++ b/frontend/src/utils/toTidyNominal.ts
@@ -1,0 +1,48 @@
+/**
+ * Creates a function that transforms untidy data into tidy format for nominal data visualization.
+ *
+ * @param domainMap - A mapping object that translates data keys to display group names
+ * @param labelKey - The property name in the data objects to use as the label identifier
+ *
+ * @returns A function that accepts untidy data and returns tidy data with the following structure:
+ * - `label`: The identifier from the original data object
+ * - `group`: The mapped group name from domainMap (or original key if not mapped)
+ * - `value`: The numerical value from the original data
+ * - `fraction`: The value as a fraction of the total numerical values in that data object
+ *
+ * @example
+ * ```typescript
+ * const domainMap = { sales: 'Sales Revenue', profit: 'Net Profit' };
+ * const transformer = toTidyNominal(domainMap, 'quarter');
+ * const untidyData = [{ quarter: 'Q1', sales: 1000, profit: 200 }];
+ * const tidyData = transformer(untidyData);
+ * // Returns: [
+ * //   { label: 'Q1', group: 'Sales Revenue', value: 1000, fraction: 0.833 },
+ * //   { label: 'Q1', group: 'Net Profit', value: 200, fraction: 0.167 }
+ * // ]
+ * ```
+ */
+export function toTidyNominal(domainMap: Record<string, string>, labelKey?: string) {
+  // return a function that transforms untidy data into tidy format
+  return (untidyData: Record<string, unknown>[]) => {
+    // interate over each object in the untidy data
+    return untidyData.flatMap((d) => {
+      const numericalEntries = Object.entries(d).filter(
+        (entry): entry is [string, number] => typeof entry[1] === 'number'
+      );
+
+      // calculate the total so we can calculate the fraction
+      const total =
+        numericalEntries.map(([, val]) => val).reduce((sum, value) => sum + (value || 0), 0) || 0;
+
+      const tidyData = numericalEntries.map(([key, value]) => ({
+        label: labelKey ? (d[labelKey] as string) : undefined,
+        group: domainMap[key] || key,
+        value,
+        fraction: (value || 0) / total,
+      }));
+
+      return tidyData;
+    });
+  };
+}


### PR DESCRIPTION
This PR adds an addition component to sthe statisitics componets for figures.

With `Statistic.Figure`, you can now render a plot by specifying a plotcon fig. It is wrapped in the same style container as the other statistics components.

Plots can be directly rendered with `PlotContainer` as well.

Example:

<img width="518" height="292" alt="image" src="https://github.com/user-attachments/assets/e51ec3be-697d-4165-a8e0-49ce39a8efc4" />
