### PR TITLE
feat: show remaining census data on tab 1 (general access)

### DIFF
--- a/frontend/src/data.d.ts
+++ b/frontend/src/data.d.ts
@@ -2,6 +2,7 @@ type CensusHouseholdsTimeSeries = CensusHouseholdsValue[];
 type CensusRaceEthnicityTimeSeries = CensusRaceEthnicityValue[];
 type CensusPopulationTotalTimeSeries = CensusPopulationTotalValue[];
 type CensusEducationalAttainmentTimeSeries = CensusEducationalAttainmentValue[];
+type CombinedCensusDataTimeSeries = CombinedCensusData[];
 type ReplicaNetworkSegments = GeoJSON<{ frequency: number; frequency_bucket: number }>;
 type ReplicaAreaPolygon = GeoJSON<{ name: string }>;
 type ReplicaSyntheticPeople = ReplicaSyntheticPerson[];
@@ -46,6 +47,15 @@ interface CensusEducationalAttainmentValue extends CoreCensusValue {
   educational_attainment__bachelor_degree: number;
   educational_attainment__graduate_or_professional_degree: number;
 }
+
+type CombinedCensusData = {
+  areas: string[];
+  /** The Census ACS year range */
+  YEAR: string;
+} & CensusHouseholdsValue &
+  CensusRaceEthnicityValue &
+  CensusPopulationTotalValue &
+  CensusEducationalAttainmentValue;
 
 type ArrayString = string;
 type LineString = string;

--- a/frontend/src/views/GeneralAccess.tsx
+++ b/frontend/src/views/GeneralAccess.tsx
@@ -167,14 +167,42 @@ function Sections() {
       />
     </Section>,
     <Section title="Area Demographics">
-      <Statistic.Number
-        wrap
-        label="Population total"
-        data={data?.map((area) => ({
-          label: area.__label,
-          value: area.population_total?.[0]?.population__total || 0,
-        }))}
-      />
+      {(() => {
+        if (data?.length === 1) {
+          const censusData = data[0]!.census_acs_5year;
+          const censusYearRange = censusData?.[0]?.YEAR;
+
+          return (
+            <Statistic.Number
+              wrap
+              label={
+                `Population estimate` + (censusYearRange ? ` (ACS ${censusYearRange})` : ' (ACS)')
+              }
+              data={data?.map((area) => ({
+                label: area.__label,
+                value:
+                  censusData
+                    ?.map((item) => item.population__total)
+                    .reduce((sum, value) => sum + (value || 0), 0) || NaN,
+              }))}
+            />
+          );
+        }
+
+        return (
+          <Statistic.Number
+            wrap
+            label="Population estimate (ACS)"
+            data={data?.map((area) => ({
+              label: area.__label,
+              value:
+                area.census_acs_5year
+                  ?.map((item) => item.population__total)
+                  .reduce((sum, value) => sum + (value || 0), 0) || NaN,
+            }))}
+          />
+        );
+      })()}
 
       <Statistic.Figure
         wrap={{ f: { gridColumn: '1 / -1' } }}

--- a/frontend/src/views/GeneralAccess.tsx
+++ b/frontend/src/views/GeneralAccess.tsx
@@ -593,11 +593,29 @@ function Sections() {
 
           return {
             label: area.__label,
-            value: (possibleConversions / allTrips).toFixed(2),
+            value: ((possibleConversions / allTrips) * 100).toFixed(2),
           };
         })}
       />
-      <Statistic.Percent wrap label="Households without a vehicle (ACS)" data={[]} />
+      <Statistic.Percent
+        wrap
+        label="Households without a vehicle (ACS)"
+        data={data?.map((area) => {
+          const households =
+            area.census_acs_5year
+              ?.map((item) => item.households__total)
+              .reduce((sum, value) => sum + (value || 0), 0) || NaN;
+          const householdsNoVehicle =
+            area.census_acs_5year
+              ?.map((item) => item.households__no_vehicle)
+              .reduce((sum, value) => sum + (value || 0), 0) || NaN;
+
+          return {
+            label: area.__label,
+            value: ((householdsNoVehicle / households) * 100).toFixed(2),
+          };
+        })}
+      />
       <Statistic.Number
         wrap
         label="Median commute time (all modes)"


### PR DESCRIPTION
- Tracts are now matched to areas based on tract centroid intersection with areas. Before, they were mistakenly matched by polygon intersection.
- The census data only fetched once per page load.
- The census data is filtered by area and year before being returned for a season-area's data object.
- The population estimate for area demographics now shows the sum of population of all intersecting tracts.
- The households without a vehicle (ACS) section now shows the sum of households without vehicles of all intersecting tracts.

Bug fix:
- Trips that could use public transit now shows the percetange value instead of showing the fraction value.