### PR TITLE
feat(pipeline): add ETL for passthrough data files and folders

### DIFF
--- a/data-pipeline/src/etl/sources/passthrough/runner.py
+++ b/data-pipeline/src/etl/sources/passthrough/runner.py
@@ -1,0 +1,8 @@
+import shutil
+
+
+def source_runner():
+    # copy the input/passthrough_data folder contents to the output folder
+    input_folder = './input/passthrough_data'
+    output_folder = './data'
+    shutil.copytree(input_folder, output_folder, dirs_exist_ok=True)


### PR DESCRIPTION
It simply copies the input/passthrough_data folder contents to the data folder.