### PR TITLE
feat(frontend): show future scenarios and routes on tab 5 (roads or transit)

### DIFF
--- a/frontend/beforeStart.js
+++ b/frontend/beforeStart.js
@@ -78,6 +78,18 @@ if (areaNames.length) {
   await buildSeasonIndex(publicDataDir + '/replica/' + areaNames[0] + '/statistics');
 }
 
+// buld an index of future routes
+const futureRoutesDir = joinPath(publicDataDir, 'future_routes');
+const futureRoutesExists = await stat(futureRoutesDir)
+  .then(() => true)
+  .catch(() => false);
+if (futureRoutesExists) {
+  const futureRoutesIndexPath = joinPath(futureRoutesDir, 'future_routes_index.txt');
+  const futureRoutesIndex = (await readdir(futureRoutesDir)).join('\n');
+  await writeFile(futureRoutesIndexPath, futureRoutesIndex, 'utf8');
+  console.log(`Future routes index written to: ${futureRoutesIndexPath}`);
+}
+
 if (!shouldLog) {
   console.log = originalConsoleLog;
 }

--- a/frontend/src/assets/theme.css
+++ b/frontend/src/assets/theme.css
@@ -12,8 +12,8 @@
   --color-primary: var(--color-green1);
   --color-secondary: var(--color-blue);
 
-  --button-radius: 3px;
-  --surface-radius: 6px;
+  --button-radius: 0.188em;
+  --surface-radius: 0.375em;
 
   --card-background-default: hsla(0, 0%, 100%, 70%);
   --control-stroke-default: hsla(0, 0%, 0%, 7%);

--- a/frontend/src/components/common/IconButton/IconButton.tsx
+++ b/frontend/src/components/common/IconButton/IconButton.tsx
@@ -14,6 +14,8 @@ interface IconButtonProps {
    * A tooltip for the icon button, which is shown on mouse hover by the browser.
    */
   title?: string;
+
+  style?: React.CSSProperties;
 }
 
 /**
@@ -27,6 +29,7 @@ export function IconButton(props: IconButtonProps) {
         onClick={props.onClick}
         className={props.disabled ? 'disabled ' + props.className : props.className}
         title={props.title}
+        style={props.style}
       >
         {props.children}
       </StyledAnchorButton>
@@ -39,6 +42,7 @@ export function IconButton(props: IconButtonProps) {
       disabled={props.disabled}
       className={props.disabled ? 'disabled ' + props.className : props.className}
       title={props.title}
+      style={props.style}
     >
       {props.children}
     </StyledButton>
@@ -46,21 +50,23 @@ export function IconButton(props: IconButtonProps) {
 }
 
 const StyledButton = styled.button`
+  font-size: 1rem;
   appearance: none;
+  padding: 0;
   display: inline-flex;
   flex-direction: row;
   justify-content: center;
   align-items: center;
-  min-inline-size: 2.25rem;
-  min-block-size: 2.25rem;
+  min-inline-size: 2.25em;
+  min-block-size: 2.25em;
   box-sizing: border-box;
   border: none;
-  box-shadow: inset 0 0 0 1px var(--control-stroke-default),
-    inset 0 -1px 0 0 var(--control-stroke-secondary-overlay);
+  box-shadow: inset 0 0 0 0.063em var(--control-stroke-default),
+    inset 0 -0.063em 0 0 var(--control-stroke-secondary-overlay);
   border-radius: var(--button-radius);
   color: inherit;
   user-select: none;
-  background-color: #fff;
+  background-color: transparent;
   flex-wrap: nowrap;
   transition: 120ms;
   ${(props) => props.title && `cursor: help;`}
@@ -76,7 +82,7 @@ const StyledButton = styled.button`
   &:active:not(.disabled) {
     background-color: var(--subtle-fill-tertiary);
     color: var(--text-secondary);
-    box-shadow: inset 0 0 0 1px var(--control-stroke-default);
+    box-shadow: inset 0 0 0 0.063em var(--control-stroke-default);
   }
 
   &.disabled {
@@ -87,8 +93,8 @@ const StyledButton = styled.button`
 
   & > svg {
     fill: currentColor;
-    block-size: 1.5rem;
-    inline-size: 1.5rem;
+    block-size: 1.5em;
+    inline-size: 1.5em;
   }
 `;
 

--- a/frontend/src/components/common/Map/Map.tsx
+++ b/frontend/src/components/common/Map/Map.tsx
@@ -138,25 +138,31 @@ export function Map(props: MapProps) {
   >();
 
   const serviceAreaLayers = {
-    walk: layers?.find((layer) => layer.id.startsWith('walk-service-area__')),
-    bike: layers?.find((layer) => layer.id.startsWith('bike-service-area__')),
-    paratransit: layers?.find((layer) => layer.id.startsWith('paratransit-service-area__')),
+    walk: layers?.filter((layer) => layer.id.startsWith('walk-service-area__')) || [],
+    bike: layers?.filter((layer) => layer.id.startsWith('bike-service-area__')) || [],
+    paratransit: layers?.filter((layer) => layer.id.startsWith('paratransit-service-area__')) || [],
   };
 
   function toggleServiceAreaLayer(layerToShow: 'walk' | 'bike' | 'paratransit') {
     // get the current visibility
-    const isVisible = serviceAreaLayers[layerToShow]?.visible;
+    const isVisible = serviceAreaLayers[layerToShow]?.every((layer) => layer.visible) ?? false;
 
     // hide allservice area layers
-    Object.values(serviceAreaLayers).forEach((layerInfo) => {
-      if (layerInfo) {
-        layerInfo.layer.visible = false;
-      }
-    });
+    Object.values(serviceAreaLayers)
+      .flatMap((l) => l)
+      .forEach((layerInfo) => {
+        if (layerInfo) {
+          layerInfo.layer.visible = false;
+        }
+      });
 
     // toggle the clicked layer
     if (serviceAreaLayers[layerToShow]) {
-      serviceAreaLayers[layerToShow].layer.visible = !isVisible;
+      serviceAreaLayers[layerToShow].forEach((layerInfo) => {
+        if (layerInfo) {
+          layerInfo.layer.visible = !isVisible;
+        }
+      });
     }
   }
 
@@ -164,7 +170,7 @@ export function Map(props: MapProps) {
     <div style={{ height: '100%' }}>
       {/* start centered on Greenville at a zoom level that shows most of the city */}
       <arcgis-map basemap="topo-vector" zoom={12} center="-82.4, 34.85" ref={mapElem}>
-        {serviceAreaLayers.walk ? (
+        {serviceAreaLayers.walk.length ? (
           <arcgis-placement position="top-left">
             <IconButton
               title="Show walk service area"
@@ -185,7 +191,7 @@ export function Map(props: MapProps) {
           </arcgis-placement>
         ) : null}
 
-        {serviceAreaLayers.bike ? (
+        {serviceAreaLayers.bike.length ? (
           <arcgis-placement position="top-left">
             <IconButton
               title="Show bike service area"
@@ -201,7 +207,7 @@ export function Map(props: MapProps) {
           </arcgis-placement>
         ) : null}
 
-        {serviceAreaLayers.paratransit ? (
+        {serviceAreaLayers.paratransit.length ? (
           <arcgis-placement position="top-left">
             <IconButton
               title="Show paratransit service area"

--- a/frontend/src/components/layout/OptionTrack/OptionTrack.tsx
+++ b/frontend/src/components/layout/OptionTrack/OptionTrack.tsx
@@ -44,7 +44,18 @@ export function OptionTrack(props: OptionTrackProps) {
   // add resize listeners to each child node
   const eachChildNode = Children.toArray(props.children)
     .filter((child): child is React.ReactElement<any, typeof OptionButton> => {
-      return isValidElement(child) && child.type === OptionButton;
+      if (!isValidElement(child)) return false;
+
+      // diirect match
+      if (child.type === OptionButton) return true;
+
+      // functional component that returns OptionButton
+      if (typeof child.type === 'function') {
+        const rendered = (child.type as any)(child.props);
+        return isValidElement(rendered) && rendered.type === OptionButton;
+      }
+
+      return false;
     })
     .map((child, index) => {
       return <ClonedChild key={index} child={child} onResize={rerenderOnResize} />;

--- a/frontend/src/data.d.ts
+++ b/frontend/src/data.d.ts
@@ -338,3 +338,253 @@ type MergedEssentialServicesAccessStats = Omit<
   'replica_table'
 > &
   Omit<EssentialServicesPopulationAccessStatistic, 'replica_table'>;
+
+interface NorthsideDataProcessing {
+  neighborhood_name?: string | null;
+  GISJOIN?: string | null;
+  age__65_over?: number | null;
+  age__under_5?: number | null;
+  disability__18_34__female?: number | null;
+  disability__18_34__male?: number | null;
+  disability__35_64__female?: number | null;
+  disability__35_64__male?: number | null;
+  disability__5_17__female?: number | null;
+  disability__5_17__male?: number | null;
+  disability__65_74__female?: number | null;
+  disability__65_74__male?: number | null;
+  disability__75_over__female?: number | null;
+  disability__75_over__male?: number | null;
+  disability__under_5__female?: number | null;
+  disability__under_5__male?: number | null;
+  edu_enrollment__black__college_undergraduate?: number | null;
+  edu_enrollment__black__graduate_professional?: number | null;
+  edu_enrollment__black__k12?: number | null;
+  edu_enrollment__black__nursery_preschool?: number | null;
+  edu_enrollment__black__total?: number | null;
+  edu_enrollment__college_undergraduate?: number | null;
+  edu_enrollment__graduate_professional?: number | null;
+  edu_enrollment__hispanic__college_undergraduate?: number | null;
+  edu_enrollment__hispanic__graduate_professional?: number | null;
+  edu_enrollment__hispanic__k12?: number | null;
+  edu_enrollment__hispanic__nursery_preschool?: number | null;
+  edu_enrollment__hispanic__total?: number | null;
+  edu_enrollment__k12?: number | null;
+  edu_enrollment__nursery_preschool?: number | null;
+  edu_enrollment__total?: number | null;
+  edu_enrollment__white__college_undergraduate?: number | null;
+  edu_enrollment__white__graduate_professional?: number | null;
+  edu_enrollment__white__k12?: number | null;
+  edu_enrollment__white__nursery_preschool?: number | null;
+  edu_enrollment__white__total?: number | null;
+  education__associates_degree?: number | null;
+  education__bachelors_degree?: number | null;
+  education__doctorate_degree?: number | null;
+  education__ged_or_alternative_credential?: number | null;
+  education__masters_degree?: number | null;
+  education__professional_school_degree?: number | null;
+  education__regular_high_school_diploma?: number | null;
+  education__some_college_no_degree?: number | null;
+  employment__black__employed?: number | null;
+  employment__black__unemployed?: number | null;
+  employment__employed?: number | null;
+  employment__hispanic__employed?: number | null;
+  employment__hispanic__unemployed?: number | null;
+  employment__unemployed?: number | null;
+  employment__white__employed?: number | null;
+  employment__white__unemployed?: number | null;
+  ethnicity__hispanic_or_latino?: number | null;
+  ethnicity__hispanic_or_latino__amer_indian_alaskan_native?: number | null;
+  ethnicity__hispanic_or_latino__asian?: number | null;
+  ethnicity__hispanic_or_latino__black?: number | null;
+  ethnicity__hispanic_or_latino__other_race?: number | null;
+  ethnicity__hispanic_or_latino__pacific_islander?: number | null;
+  ethnicity__hispanic_or_latino__white?: number | null;
+  ethnicity__not_hispanic_or_latino?: number | null;
+  ethnicity__not_hispanic_or_latino__amer_indian_alaskan_native?: number | null;
+  ethnicity__not_hispanic_or_latino__asian?: number | null;
+  ethnicity__not_hispanic_or_latino__black?: number | null;
+  ethnicity__not_hispanic_or_latino__other_race?: number | null;
+  ethnicity__not_hispanic_or_latino__pacific_islander?: number | null;
+  ethnicity__not_hispanic_or_latino__two_or_more_races?: number | null;
+  ethnicity__not_hispanic_or_latino__white?: number | null;
+  food_stamps__not_received?: number | null;
+  food_stamps__not_received__above_poverty?: number | null;
+  food_stamps__not_received__below_poverty?: number | null;
+  food_stamps__received?: number | null;
+  food_stamps__received__above_poverty?: number | null;
+  food_stamps__received__below_poverty?: number | null;
+  geographic_mobility__abroad?: number | null;
+  geographic_mobility__different_county_same_state?: number | null;
+  geographic_mobility__different_state?: number | null;
+  geographic_mobility__no_income?: number | null;
+  geographic_mobility__no_movement?: number | null;
+  geographic_mobility__same_county?: number | null;
+  geographic_mobility__with_income?: number | null;
+  grandparent__not_responsible_for_grandchild_under_18?: number | null;
+  grandparent__responsible_for_grandchild_under_18?: number | null;
+  has_computer__black?: number | null;
+  has_computer__hispanic?: number | null;
+  has_computer__total?: number | null;
+  has_computer__white?: number | null;
+  household_vehicles__0?: number | null;
+  housing__total_occupied?: number | null;
+  industry_employment__recreation_services_etc?: number | null;
+  industry_employment__social_services_etc?: number | null;
+  insurance_coverage__black__with_insurance?: number | null;
+  insurance_coverage__black__without_insurance?: number | null;
+  insurance_coverage__hispanic__with_insurance?: number | null;
+  insurance_coverage__hispanic__without_insurance?: number | null;
+  insurance_coverage__white__with_insurance?: number | null;
+  insurance_coverage__white__without_insurance?: number | null;
+  insurance_coverage__with_insurance?: number | null;
+  insurance_coverage__without_insurance?: number | null;
+  internet__broadband__black?: number | null;
+  internet__broadband__hispanic?: number | null;
+  internet__broadband__total?: number | null;
+  internet__broadband__white?: number | null;
+  median_household_income?: number | null;
+  median_household_income__white?: number | null;
+  no_computer__black?: number | null;
+  no_computer__hispanic?: number | null;
+  no_computer__total?: number | null;
+  no_computer__white?: number | null;
+  population__25_or_older?: number | null;
+  population__children_living_with_grandparent_householder?: number | null;
+  population__total?: number | null;
+  poverty__above_poverty_household?: number | null;
+  poverty__below_poverty_household?: number | null;
+  tenure__black__owner?: number | null;
+  tenure__black__renter?: number | null;
+  tenure__hispanic__owner?: number | null;
+  tenure__hispanic__renter?: number | null;
+  tenure__owner?: number | null;
+  tenure__owner_15_24?: number | null;
+  tenure__owner_25_34?: number | null;
+  tenure__owner_35_44?: number | null;
+  tenure__owner_45_54?: number | null;
+  tenure__owner_55_59?: number | null;
+  tenure__owner_60_64?: number | null;
+  tenure__owner_65_74?: number | null;
+  tenure__owner_75_84?: number | null;
+  tenure__owner_85_over?: number | null;
+  tenure__renter?: number | null;
+  tenure__renter_15_24?: number | null;
+  tenure__renter_25_34?: number | null;
+  tenure__renter_35_44?: number | null;
+  tenure__renter_45_54?: number | null;
+  tenure__renter_55_59?: number | null;
+  tenure__renter_60_64?: number | null;
+  tenure__renter_65_74?: number | null;
+  tenure__renter_75_84?: number | null;
+  tenure__renter_85_over?: number | null;
+  tenure__white__owner?: number | null;
+  tenure__white__renter?: number | null;
+  veteran__18_to_64_years?: number | null;
+  veteran__65_years_and_over?: number | null;
+  vision_difficulty__18_34__female?: number | null;
+  vision_difficulty__18_34__male?: number | null;
+  vision_difficulty__35_64__female?: number | null;
+  vision_difficulty__35_64__male?: number | null;
+  vision_difficulty__5_17__female?: number | null;
+  vision_difficulty__5_17__male?: number | null;
+  vision_difficulty__65_74__female?: number | null;
+  vision_difficulty__65_74__male?: number | null;
+  vision_difficulty__75_over__female?: number | null;
+  vision_difficulty__75_over__male?: number | null;
+  vision_difficulty__under_5__female?: number | null;
+  vision_difficulty__under_5__male?: number | null;
+  household_vehicles__none_fraction?: number | null;
+  age__under_5_fraction?: number | null;
+  age__65_over_fraction?: number | null;
+  population__children_living_with_grandparent_householder_fraction?: number | null;
+  grandparent__responsible_for_grandchild_under_18_fraction?: number | null;
+  grandparent__not_responsible_for_grandchild_under_18_fraction?: number | null;
+  geographic_mobility__no_movement_fraction?: number | null;
+  geographic_mobility__same_county_fraction?: number | null;
+  geographic_mobility__different_county_same_state_fraction?: number | null;
+  geographic_mobility__different_state_fraction?: number | null;
+  geographic_mobility__abroad_fraction?: number | null;
+  geographic_mobility__no_income_fraction?: number | null;
+  geographic_mobility__with_income_fraction?: number | null;
+  industry__service_fraction?: number | null;
+  food_stamps__received_fraction?: number | null;
+  poverty__below_poverty_household_fraction?: number | null;
+  poverty__above_poverty_household_fraction?: number | null;
+  has_computer__total_percent?: number | null;
+  has_computer__black_percent?: number | null;
+  has_computer__white_percent?: number | null;
+  has_computer__hispanic_percent?: number | null;
+  internet__broadband__total_percent?: number | null;
+  internet__broadband__black_percent?: number | null;
+  internet__broadband__white_percent?: number | null;
+  internet__broadband__hispanic_percent?: number | null;
+  disability__total?: number | null;
+}
+
+interface Scenario {
+  pavementMiles: number;
+  estimatedCostUSD: number;
+  scenarioName: string;
+  features: (
+    | ScenarioStopInfrastructureFeature
+    | ScenarioStopAccessibilityFeature
+    | ScenarioRouteFrequencyFeature
+    | ScenarioRouteAdditionFeature
+    | ScenarioBusPurchaseFeature
+    | ScenarioOnDemandPurchaseFeature
+  )[];
+}
+
+interface ScenarioFeature {
+  name: string;
+  description?: string;
+  additionalNote?: string;
+}
+
+interface ScenarioStopFeature extends ScenarioFeature {
+  affects: 'stops';
+}
+
+interface ScenarioRouteFeature extends ScenarioFeature {
+  affects: 'routes';
+  routeIds: string[];
+}
+
+interface ScenarioBusFeature extends ScenarioFeature {
+  affects: 'buses';
+}
+
+interface ScenarioOnDemandFeature extends ScenarioFeature {
+  affects: 'on-demand';
+}
+
+interface ScenarioStopInfrastructureFeature extends ScenarioStopFeature {
+  type: 'infrastructure';
+  count: number;
+}
+
+interface ScenarioStopAccessibilityFeature extends ScenarioStopFeature {
+  type: 'accessibility';
+  count: number;
+}
+
+interface ScenarioRouteFrequencyFeature extends ScenarioRouteFeature {
+  type: 'frequency';
+  before: number;
+  after: number;
+}
+
+interface ScenarioRouteAdditionFeature extends ScenarioRouteFeature {
+  type: 'addition';
+  frequency: number;
+}
+
+interface ScenarioBusPurchaseFeature extends ScenarioBusFeature {
+  type: 'purchase';
+  count: number;
+}
+
+interface ScenarioOnDemandPurchaseFeature extends ScenarioOnDemandFeature {
+  type: 'purchase';
+  count: number;
+}

--- a/frontend/src/hooks/useAppData.ts
+++ b/frontend/src/hooks/useAppData.ts
@@ -706,12 +706,12 @@ async function constructScenarioDataPromises() {
           handleError(`future_route_stats_${routeId}`, true, true)
         ),
       route: (abortSignal?: AbortSignal) =>
-        fetchData<GeoJSON<unknown, 'LineString' | 'MultiLineString'>>(
+        fetchData<GeoJSON<Record<string, unknown>, 'LineString' | 'MultiLineString'>>(
           `${folderPath}/route.geojson.deflate`,
           abortSignal
         ).catch(handleError(`future_route_${routeId}`, true, true)),
       stops: (abortSignal?: AbortSignal) =>
-        fetchData<GeoJSON<unknown, 'Point'>>(
+        fetchData<GeoJSON<Record<string, unknown>, 'Point'>>(
           `${folderPath}/stops.geojson.deflate`,
           abortSignal
         ).catch(handleError(`future_route_stops_${routeId}`, true, true)),
@@ -727,9 +727,9 @@ async function constructScenarioDataPromises() {
         ).catch(handleError(`future_route_bike_service_area_${routeId}`, true, true)),
       paratransit_service_area: (abortSignal?: AbortSignal) =>
         fetchData<GeoJSON<NorthsideDataProcessing, 'Polygon' | 'MultiPolygon'>>(
-          `${folderPath}/paratransit_service_area.geojson.deflate`,
+          `${folderPath}/paratransit.geojson.deflate`,
           abortSignal
-        ).catch(handleError(`paratransit${routeId}`, true, true)),
+        ).catch(handleError(`future_route_paratrasnit_service_area${routeId}`, true, true)),
     };
   });
 

--- a/frontend/src/utils/renderers/createBusStopRenderer.ts
+++ b/frontend/src/utils/renderers/createBusStopRenderer.ts
@@ -1,8 +1,9 @@
+import Color from '@arcgis/core/Color';
 import { SimpleRenderer } from '@arcgis/core/renderers.js';
 import SizeVariable from '@arcgis/core/renderers/visualVariables/SizeVariable';
 import { CIMSymbol } from '@arcgis/core/symbols';
 
-export function createBusStopRenderer() {
+export function createBusStopRenderer(backgroundColor: Color = new Color([51, 51, 51, 255])) {
   return new SimpleRenderer({
     symbol: new CIMSymbol({
       data: {
@@ -207,7 +208,7 @@ export function createBusStopRenderer() {
                       {
                         type: 'CIMSolidFill',
                         enable: true,
-                        color: [51, 51, 51, 255],
+                        color: backgroundColor.toJSON(),
                       },
                     ],
                   },

--- a/frontend/src/views/RoadsVsTransit.tsx
+++ b/frontend/src/views/RoadsVsTransit.tsx
@@ -1,18 +1,51 @@
 import '@arcgis/map-components/dist/components/arcgis-map';
 import styled from '@emotion/styled';
 import React, { ComponentProps, useRef, useState } from 'react';
-import { CoreFrame, IconButton, OptionTrack, SelectOne } from '../components';
+import { CoreFrame, IconButton, Map, OptionTrack, SelectOne } from '../components';
 import { AppNavigation } from '../components/navigation';
 import { useAppData, useRect } from '../hooks';
+import { useFutureMapData, useMapData } from '../hooks/useMapData';
+import { notEmpty } from '../utils';
 
 export function RoadsVsTransit() {
+  const { data, scenarios: scenariosData } = useAppData();
+  const {
+    areaPolygons,
+    routes,
+    stops,
+    walkServiceAreas,
+    cyclingServiceAreas,
+    paratransitServiceAreas,
+  } = useMapData(data);
+  const {
+    futureRoutes,
+    futureStops,
+    futureWalkServiceAreas,
+    futureCyclingServiceAreas,
+    futureParatransitServiceAreas,
+  } = useFutureMapData(scenariosData.data?.futureRoutes || []);
+
   return (
     <CoreFrame
       outerStyle={{ height: '100%' }}
       header={<AppNavigation />}
       map={
         <div style={{ height: '100%' }}>
-          <arcgis-map basemap="topo-vector" zoom={12} center="-82.4, 34.85"></arcgis-map>
+          <Map
+            layers={[
+              ...futureWalkServiceAreas,
+              walkServiceAreas,
+              ...futureCyclingServiceAreas,
+              cyclingServiceAreas,
+              ...futureParatransitServiceAreas,
+              paratransitServiceAreas,
+              ...futureRoutes,
+              routes,
+              ...futureStops,
+              stops,
+              ...areaPolygons,
+            ].filter(notEmpty)}
+          />
         </div>
       }
       sections={[<Comparison />]}


### PR DESCRIPTION
This is the initial implementation of the data for tab 5.

- mile-based scenarios are now shown on the options track
- each mile-based scenario lets you choose between the available possibilities for the mile-based scenario
- each possibility lets to cycle through the new/changed features for that possiiblity (new stops, more benches, increased frequency, etc.)
- the map now shows all future routes, stops, and service areas in green
- the map also shows the current routes, stops, and service areas in their normal colors

Next phases will include:
- showing bench installation locations when the bench stats are shown
- highlight routes that are changed or added when a route-based stat is shown

<img width="1075" height="905" alt="image" src="https://github.com/user-attachments/assets/1784f16a-fc52-48b1-9567-00a35371ff64" />

https://github.com/user-attachments/assets/a779bb99-cc81-4580-b82b-70d58b714db8


