### PR TITLE
feat: add map, coverage stats, work and school stats, and travel mode figure for tab 2 (future opportunities)

### DIFF
--- a/data-pipeline/src/etl/sources/future_routes/etl.py
+++ b/data-pipeline/src/etl/sources/future_routes/etl.py
@@ -4,16 +4,20 @@ import logging
 import os
 import shutil
 from pathlib import Path
-from typing import Literal, Self, cast
+from typing import Any, Literal, Optional, Self, cast
 
+import dask.dataframe
 import geopandas
 import pandas
+import pyogrio
 import requests
 import tqdm
 
 from etl.geodesic import geodesic_buffer_series
 from etl.sources.census_acs_5year.constants import tiger_web_tracts_services
-from etl.sources.replica.process_etl import Season
+from etl.sources.replica.process_etl import (
+    Season, count_destination_building_use_in_service_area,
+    count_median_commute_time, count_trip_travel_methods)
 from etl.sources.replica.transformers.count_segment_frequency import \
     count_segment_frequency_multi_input
 
@@ -89,10 +93,17 @@ class FutureRoutesETL:
         for scenario_folder in scenarios:
             logger.info(f'Processing scenario: {scenario_folder.name}')
 
-            stats = {}
+            stats: dict[str, Any] = {}
 
             # find convertable trips for the scenario
-            stats['counts'] = self.find_convertable_trips(scenario_folder, day='thursday')
+            stats['possible_conversions'] = self.find_convertable_trips(
+                scenario_folder, day='thursday')
+
+            # find travel methods, median commute time, and destination building use for trips in the scenario
+            trip_stats = self.calculate_trip_statistics(
+                day='thursday', scenario_input_folder=scenario_folder)
+            for key, value in trip_stats.items():
+                stats[key] = value
 
             # copy all input files to the output folder
             for file in scenario_folder.glob('*.geojson'):
@@ -269,6 +280,51 @@ class FutureRoutesETL:
         del overall_bike_service_area
 
         return {
-            'walk_convertable_count': walk_sum,
-            'bike_convertable_count': bike_sum,
+            'via_walk': walk_sum,
+            'via_bike': bike_sum,
         }
+
+    def calculate_trip_statistics(self, day: Literal['saturday', 'thursday'], scenario_input_folder: Path) -> dict[str, Any]:
+        walk_service_area_path = scenario_input_folder / self.required_scenario_files['walkshed']
+        bike_service_area_path = scenario_input_folder / self.required_scenario_files['bikeshed']
+        season_str = f'{self.season['region']}_{self.season["year"]}_{self.season["quarter"]}'
+
+        walk_gdf = geopandas.read_file(walk_service_area_path, columns=['geometry'])
+        bike_gdf = geopandas.read_file(bike_service_area_path, columns=['geometry'])
+
+        trips_chunks_folder_path = self.replica_output_folder / 'full_area' / \
+            f'{day}_trip' / '_chunks' / f'{season_str}_{day}_trip'
+        trips_chunks_ddf = cast(dask.dataframe.DataFrame,
+                                dask.dataframe.read_parquet(trips_chunks_folder_path, columns=['tour_type', 'mode', 'duration_minutes', 'destination_building_use_l1', 'destination_building_use_l2', 'end_lng', 'end_lat']))
+        logger.debug(f'Computing DataFrame...')
+        trips_df = trips_chunks_ddf.compute()
+
+        # read the CRS from the first chunk geoparquet file since we will lose it when we read it to a dataframe instead of a geodataframe
+        metadata = pyogrio.read_info(next(trips_chunks_folder_path.glob('*.parquet')))
+        crs = metadata['crs']
+
+        statistics: dict[str, Any] = {
+            'methods': {},
+            'median_duration': {},
+            'destination_building_use': {}
+        }
+
+        # count trip travel methods
+        logger.debug('    Counting trip travel methods...')
+        statistics['methods'] = count_trip_travel_methods(trips_df)
+
+        # calculate median trip commute time
+        logger.debug('    Calculating median trip commute time...')
+        statistics['median_duration'] = count_median_commute_time(trips_df)
+
+        if not walk_service_area_path.exists() or not bike_service_area_path.exists():
+            logger.warning(
+                f'Missing walk or bike service area files in {scenario_input_folder.name}. Skipping building use analysis.')
+            return statistics
+
+        # get destination building uses for trips that use or could use public transit
+        logger.debug('    Counting destination building uses...')
+        statistics['destination_building_use'] = count_destination_building_use_in_service_area(
+            trips_df, crs, walk_gdf, bike_gdf)
+
+        return statistics

--- a/data-pipeline/src/etl/sources/future_routes/etl.py
+++ b/data-pipeline/src/etl/sources/future_routes/etl.py
@@ -4,22 +4,18 @@ import logging
 import os
 import shutil
 from pathlib import Path
-from typing import Any, Literal, Optional, Self, cast
+from typing import Any, Literal, Self, cast
 
 import dask.dataframe
 import geopandas
 import pandas
 import pyogrio
-import requests
 import tqdm
 
-from etl.geodesic import geodesic_buffer_series
-from etl.sources.census_acs_5year.constants import tiger_web_tracts_services
+from etl.geodesic import geodesic_area_series, geodesic_length_series
 from etl.sources.replica.process_etl import (
     Season, count_destination_building_use_in_service_area,
     count_median_commute_time, count_trip_travel_methods)
-from etl.sources.replica.transformers.count_segment_frequency import \
-    count_segment_frequency_multi_input
 
 logger = logging.getLogger('future_routes_etl')
 logger.setLevel(logging.DEBUG)
@@ -103,6 +99,11 @@ class FutureRoutesETL:
             trip_stats = self.calculate_trip_statistics(
                 day='thursday', scenario_input_folder=scenario_folder)
             for key, value in trip_stats.items():
+                stats[key] = value
+
+            # measure coverage for the scenario
+            coverage_stats = self.measure_coverage(scenario_input_folder=scenario_folder)
+            for key, value in coverage_stats.items():
                 stats[key] = value
 
             # copy all input files to the output folder
@@ -326,5 +327,85 @@ class FutureRoutesETL:
         logger.debug('    Counting destination building uses...')
         statistics['destination_building_use'] = count_destination_building_use_in_service_area(
             trips_df, crs, walk_gdf, bike_gdf)
+
+        return statistics
+
+    def measure_coverage(self, scenario_input_folder: Path) -> dict[str, Any]:
+        walk_service_area_path = scenario_input_folder / self.required_scenario_files['walkshed']
+        bike_service_area_path = scenario_input_folder / self.required_scenario_files['bikeshed']
+        route_path = scenario_input_folder / self.required_scenario_files['route']
+        stops_path = scenario_input_folder / self.required_scenario_files['stops']
+        season_str = f'{self.season['region']}_{self.season["year"]}_{self.season["quarter"]}'
+
+        logger.info(
+            f'Reading service areas from {walk_service_area_path} and {bike_service_area_path}...')
+        walk_gdf = geopandas.read_file(walk_service_area_path, columns=['geometry'])
+        bike_gdf = geopandas.read_file(bike_service_area_path, columns=['geometry'])
+
+        # get the total bounds for the walk and bike service areas
+        logger.debug('Calculating total bounds for service areas...')
+        walk_bounds = walk_gdf.total_bounds
+        bike_bounds = bike_gdf.total_bounds
+        total_bounds = [
+            min(walk_bounds[0], bike_bounds[0]),
+            min(walk_bounds[1], bike_bounds[1]),
+            max(walk_bounds[2], bike_bounds[2]),
+            max(walk_bounds[3], bike_bounds[3])
+        ]
+
+        population_home_path = self.replica_output_folder / \
+            'full_area' / 'population' / f'{season_str}_home.parquet'
+        logger.debug(
+            f'Reading population home data from {population_home_path} with bbox {total_bounds}...')
+        population_home_gdf = geopandas.read_parquet(
+            population_home_path,
+            columns=['household_id', 'person_id', 'geometry'],
+            bbox=total_bounds
+        )
+
+        statistics: dict[str, Any] = {
+            'synthetic_demographics': {}
+        }
+
+        # count households and population covered by the service areas (home-based)
+        logger.debug('Counting households and population in future service areas...')
+
+        statistics['synthetic_demographics']['households_in_service_area'] = {}
+        statistics['synthetic_demographics']['households_in_service_area']['walk'] = population_home_gdf[
+            population_home_gdf.intersects(walk_gdf.union_all())
+        ]['household_id'].nunique()
+        statistics['synthetic_demographics']['households_in_service_area']['bike'] = population_home_gdf[
+            population_home_gdf.intersects(bike_gdf.union_all())
+        ]['household_id'].nunique()
+
+        statistics['synthetic_demographics']['population_in_service_area'] = {}
+        statistics['synthetic_demographics']['population_in_service_area']['walk'] = population_home_gdf[
+            population_home_gdf.intersects(walk_gdf.union_all())
+        ]['person_id'].nunique()
+        statistics['synthetic_demographics']['population_in_service_area']['bike'] = population_home_gdf[
+            population_home_gdf.intersects(bike_gdf.union_all())
+        ]['person_id'].nunique()
+
+        # calculate the distance of the routes in meters
+        logger.debug('Calculating route distances...')
+        routes_gdf = geopandas.read_file(route_path, columns=['geometry'])
+        distance_meters = geodesic_length_series(routes_gdf.geometry)
+
+        # count the number of stops
+        logger.debug('Counting stops...')
+        stops_gdf = geopandas.read_file(stops_path, columns=['geometry'])
+        stops_count = len(stops_gdf)
+
+        # calculate the service coverage for each service area
+        logger.debug('Calculating service area coverage...')
+        walk_perimeter, walk_area = geodesic_area_series(walk_gdf.geometry)
+        bike_perimeter, bike_area = geodesic_area_series(bike_gdf.geometry)
+
+        statistics['route_distance_meters'] = distance_meters
+        statistics['stops_count'] = stops_count
+        statistics['walk_service_area_perimeter_meters'] = walk_perimeter
+        statistics['walk_service_area_area_square_meters'] = walk_area
+        statistics['bike_service_area_perimeter_meters'] = bike_perimeter
+        statistics['bike_service_area_area_square_meters'] = bike_area
 
         return statistics

--- a/frontend/src/components/common/Statistic/plot/presets/hoizontalBar.ts
+++ b/frontend/src/components/common/Statistic/plot/presets/hoizontalBar.ts
@@ -150,7 +150,17 @@ export function horizontalBar(params: HorizontalBarParams) {
         y: (d) => (d.y1 + d.y2) / 2,
         text: (d) => {
           const showPercent = d[params.x] <= 0.05;
-          return showPercent ? `${d3.format('.0%')(d[params.x])}` : '';
+          if (!showPercent) {
+            return '';
+          }
+
+          const legendName = d[params.y] as string;
+          const showLessThan = d[params.x] < 0.01;
+          if (showLessThan) {
+            return '< 1%' + ` (${legendName})`;
+          }
+
+          return `${d3.format('.0%')(d[params.x])}`;
         },
         dx: 6,
         textAnchor: 'start',

--- a/frontend/src/components/options/futures/SelectedFutureRoutes.tsx
+++ b/frontend/src/components/options/futures/SelectedFutureRoutes.tsx
@@ -1,0 +1,52 @@
+import { useSearchParams } from 'react-router';
+import { notEmpty } from '../../../utils';
+import { SelectMany, SelectOne } from '../../common';
+import { useComparisonModeState } from '../compare/useComparisonModeState';
+
+interface SelectedFutureRoutesProps {
+  routeIds: string[];
+}
+
+export function SelectedFutureRoutes({ routeIds }: SelectedFutureRoutesProps) {
+  const [isComparing] = useComparisonModeState();
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const currentSelectedFutures = searchParams.get('futures')?.split(',').filter(notEmpty) || [];
+
+  function handleChange(value: string | string[]) {
+    if (Array.isArray(value)) {
+      if (value.length === 0) {
+        searchParams.delete('futures');
+      } else {
+        searchParams.set('futures', value.join(','));
+      }
+    } else {
+      if (value === '') {
+        searchParams.delete('futures');
+      } else {
+        searchParams.set('futures', value);
+      }
+    }
+    setSearchParams(searchParams);
+  }
+
+  return (
+    <div>
+      <label>Future Route{isComparing ? 's' : ''}</label>
+      {isComparing ? (
+        <SelectMany
+          options={routeIds}
+          onChange={handleChange}
+          selectedOptions={currentSelectedFutures}
+          showId={false}
+        />
+      ) : (
+        <SelectOne
+          onChange={handleChange}
+          options={routeIds}
+          value={currentSelectedFutures[0] || ''}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/options/futures/index.ts
+++ b/frontend/src/components/options/futures/index.ts
@@ -1,0 +1,1 @@
+export { SelectedFutureRoutes } from './SelectedFutureRoutes';

--- a/frontend/src/components/options/index.ts
+++ b/frontend/src/components/options/index.ts
@@ -1,4 +1,5 @@
 export * from './areas';
 export * from './compare';
+export * from './futures';
 export * from './seasons';
 export { SelectTravelMethod } from './travel-method/SelectTravelMethod';

--- a/frontend/src/data.d.ts
+++ b/frontend/src/data.d.ts
@@ -370,6 +370,16 @@ interface FutureRouteStatistics {
       subtype_counts: ReplicaDesinationUseSubTypeStatistics;
     };
   };
+  synthetic_demographics: {
+    households_in_service_area: { walk: number; bike: number };
+    population_in_service_area: { walk: number; bike: number };
+  };
+  route_distance_meters: number;
+  stops_count: number;
+  walk_service_area_perimeter_meters: number;
+  walk_service_area_area_square_meters: number;
+  bike_service_area_perimeter_meters: number;
+  bike_service_area_area_square_meters: number;
 }
 
 interface NorthsideDataProcessing {

--- a/frontend/src/data.d.ts
+++ b/frontend/src/data.d.ts
@@ -339,6 +339,39 @@ type MergedEssentialServicesAccessStats = Omit<
 > &
   Omit<EssentialServicesPopulationAccessStatistic, 'replica_table'>;
 
+interface FutureRouteStatistics {
+  /** Mode statistics broken down by tour type */
+  methods: {
+    __all: ReplicaTripModeStatistics;
+    commute: ReplicaTripModeStatistics;
+    work_based: ReplicaTripModeStatistics;
+    undirected: ReplicaTripModeStatistics;
+    other_home_based: ReplicaTripModeStatistics;
+  };
+  /** The median duration in minutes broken down by tour type */
+  median_duration: {
+    __all: number;
+    commute: number;
+    work_based: number;
+    undirected: number;
+    other_home_based: number;
+  };
+  possible_conversions: {
+    via_walk?: number;
+    via_bike?: number;
+  };
+  destination_building_use?: {
+    via_walk: {
+      type_counts: ReplicaDesinationUseTypeStatistics;
+      subtype_counts: ReplicaDesinationUseSubTypeStatistics;
+    };
+    via_bike: {
+      type_counts: ReplicaDesinationUseTypeStatistics;
+      subtype_counts: ReplicaDesinationUseSubTypeStatistics;
+    };
+  };
+}
+
 interface NorthsideDataProcessing {
   neighborhood_name?: string | null;
   GISJOIN?: string | null;

--- a/frontend/src/hooks/useAppData.ts
+++ b/frontend/src/hooks/useAppData.ts
@@ -698,11 +698,10 @@ async function constructScenarioDataPromises() {
     const folderPath = './data/future_routes/' + routeId;
 
     return {
-      __routeId: () => new Promise((resolve) => resolve(routeId)),
+      __routeId: () => new Promise<string>((resolve) => resolve(routeId)),
+      __label: () => new Promise<string>((resolve) => resolve(`${routeId} (Future Route)`)),
       stats: (abortSignal?: AbortSignal) =>
-        fetchData<{
-          counts: { walk_convertable_count: number; bike_convertable_count: number };
-        }>(`${folderPath}/stats.json.deflate`, abortSignal).catch(
+        fetchData<FutureRouteStatistics>(`${folderPath}/stats.json.deflate`, abortSignal).catch(
           handleError(`future_route_stats_${routeId}`, true, true)
         ),
       route: (abortSignal?: AbortSignal) =>

--- a/frontend/src/hooks/useMapData.tsx
+++ b/frontend/src/hooks/useMapData.tsx
@@ -496,9 +496,21 @@ export function useMapData(data: AppData) {
   };
 }
 
-export function useFutureMapData(data: AppFutureRoutesData) {
+/**
+ * Returns layers for an ArcGIS map that represent future routes, stops, and service areas.
+ *
+ * @param data Future routes data from the useAppData hook.
+ * @param allowedRouteIds If porivded, only routes with these IDs will be included.
+ *                        If not provided, all future routes will be included.
+ * @returns
+ */
+export function useFutureMapData(data: AppFutureRoutesData, allowedRouteIds?: string[]) {
+  const filteredData = allowedRouteIds
+    ? data.filter((d) => allowedRouteIds.includes(d.__routeId))
+    : data;
+
   const futureRoutes = useMemo(() => {
-    return (data || [])
+    return filteredData
       .filter(notEmpty)
       .filter(requireKey('route'))
       .map(({ route, __routeId }) => {
@@ -515,10 +527,10 @@ export function useFutureMapData(data: AppFutureRoutesData) {
           }),
         } satisfies GeoJSONLayerInit;
       });
-  }, [data]);
+  }, [filteredData]);
 
   const futureStops = useMemo(() => {
-    return (data || [])
+    return filteredData
       .filter(notEmpty)
       .filter(requireKey('stops'))
       .map(({ stops, __routeId }) => {
@@ -530,10 +542,10 @@ export function useFutureMapData(data: AppFutureRoutesData) {
           popupEnabled: true,
         } satisfies GeoJSONLayerInit;
       });
-  }, [data]);
+  }, [filteredData]);
 
   const futureWalkServiceAreas = useMemo(() => {
-    return (data || [])
+    return filteredData
       .filter(notEmpty)
       .filter(requireKey('walk_service_area'))
       .map(({ walk_service_area, __routeId }) => {
@@ -545,10 +557,10 @@ export function useFutureMapData(data: AppFutureRoutesData) {
           visible: false,
         } satisfies GeoJSONLayerInit;
       });
-  }, [data]);
+  }, [filteredData]);
 
   const futureCyclingServiceAreas = useMemo(() => {
-    return (data || [])
+    return filteredData
       .filter(notEmpty)
       .filter(requireKey('bike_service_area'))
       .map(({ bike_service_area, __routeId }) => {
@@ -560,10 +572,10 @@ export function useFutureMapData(data: AppFutureRoutesData) {
           visible: false,
         } satisfies GeoJSONLayerInit;
       });
-  }, [data]);
+  }, [filteredData]);
 
   const futureParatransitServiceAreas = useMemo(() => {
-    return (data || [])
+    return filteredData
       .filter(requireKey('paratransit_service_area'))
       .filter(notEmpty)
       .map(({ paratransit_service_area, __routeId }) => {
@@ -575,7 +587,7 @@ export function useFutureMapData(data: AppFutureRoutesData) {
           visible: false,
         } satisfies GeoJSONLayerInit;
       });
-  }, [data]);
+  }, [filteredData]);
 
   return {
     futureRoutes,

--- a/frontend/src/views/FutureOpportunities.tsx
+++ b/frontend/src/views/FutureOpportunities.tsx
@@ -1,17 +1,264 @@
 import '@arcgis/map-components/dist/components/arcgis-map';
-import { CoreFrame } from '../components';
+import { useLocation, useSearchParams } from 'react-router';
+import {
+  Button,
+  CoreFrame,
+  Map,
+  Section,
+  SectionEntry,
+  SidebarContent,
+  Statistic,
+} from '../components';
 import { AppNavigation } from '../components/navigation';
+import {
+  ComparisonModeSwitch,
+  SelectedFutureRoutes,
+  useComparisonModeState,
+} from '../components/options';
+import { useAppData, useMapData } from '../hooks';
+import { useFutureMapData } from '../hooks/useMapData';
+import { notEmpty, toTidyNominal } from '../utils';
 
 export function FutureOpportunities() {
+  const { data, scenarios: scenariosData } = useAppData();
+
+  const [isComparing] = useComparisonModeState();
+  const [searchParams] = useSearchParams();
+  const selectedRouteIds = (searchParams.get('futures')?.split(',').filter(notEmpty) || []).slice(
+    0,
+    isComparing ? undefined : 1
+  );
+
+  const {
+    areaPolygons,
+    routes,
+    stops,
+    walkServiceAreas,
+    cyclingServiceAreas,
+    paratransitServiceAreas,
+  } = useMapData(data);
+  const {
+    futureRoutes,
+    futureStops,
+    futureWalkServiceAreas,
+    futureCyclingServiceAreas,
+    futureParatransitServiceAreas,
+  } = useFutureMapData(scenariosData.data?.futureRoutes || [], selectedRouteIds);
+
   return (
     <CoreFrame
       outerStyle={{ height: '100%' }}
       header={<AppNavigation />}
+      sidebar={<Sidebar />}
       map={
         <div style={{ height: '100%' }}>
-          <arcgis-map basemap="topo-vector" zoom={12} center="-82.4, 34.85"></arcgis-map>
+          <Map
+            layers={[
+              ...futureWalkServiceAreas,
+              walkServiceAreas,
+              ...futureCyclingServiceAreas,
+              cyclingServiceAreas,
+              ...futureParatransitServiceAreas,
+              paratransitServiceAreas,
+              ...futureRoutes,
+              routes,
+              ...futureStops,
+              stops,
+              ...areaPolygons,
+            ].filter(notEmpty)}
+          />
         </div>
       }
+      sections={Sections()}
     />
+  );
+}
+
+function Sections() {
+  const { scenarios } = useAppData();
+  const { data: scenariosData } = scenarios;
+  const { search } = useLocation();
+
+  const [isComparing] = useComparisonModeState();
+  const [searchParams] = useSearchParams();
+  const selectedRouteIds = (searchParams.get('futures')?.split(',').filter(notEmpty) || []).slice(
+    0,
+    isComparing ? undefined : 1
+  );
+  const futures = (scenariosData?.futureRoutes || []).filter((future) =>
+    selectedRouteIds.includes(future.__routeId)
+  );
+
+  return [
+    <Section title="Coverage">
+      <Statistic.Number
+        wrap
+        label="Route length"
+        data={futures.map(({ stats, __routeId }) => {
+          const meters_distance = stats?.route_distance_meters || 0;
+          const miles_distance = meters_distance / 1609.344; // convert meters to miles
+
+          return {
+            label: __routeId,
+            value: miles_distance.toFixed(2),
+          };
+        })}
+        unit="miles"
+      />
+      <Statistic.Number
+        wrap
+        label="Route stops"
+        data={futures.map(({ stats, __routeId }) => {
+          return {
+            label: __routeId,
+            value: stats?.stops_count ?? NaN,
+          };
+        })}
+      />
+      <Statistic.Number
+        wrap
+        label="Service coverage"
+        data={futures.map(({ stats, __routeId }) => {
+          const meters_area = stats?.walk_service_area_area_square_meters || 0;
+          const miles_area = meters_area / 1609.344 / 1609.344; // convert square meters to square miles
+
+          return {
+            label: __routeId,
+            value: miles_area.toFixed(2),
+          };
+        })}
+        unit="square miles"
+      />
+    </Section>,
+    <Section title="Work and School">
+      <Statistic.Percent
+        wrap
+        label="Trips currently using public transit"
+        data={futures.map(({ stats, __routeId }) => {
+          const publicTransitTrips = stats?.methods.commute.public_transit ?? NaN;
+          const allTrips = Object.values(stats?.methods.commute || {}).reduce(
+            (sum, value) => sum + (value || 0),
+            0
+          );
+
+          return {
+            label: __routeId,
+            value: ((publicTransitTrips / allTrips) * 100).toFixed(2),
+          };
+        })}
+      />
+      <Statistic.Percent
+        wrap
+        label="Trips that could use public transit"
+        data={futures.map(({ stats, __routeId }) => {
+          const possibleConversions = stats?.possible_conversions.via_walk || 0;
+          const allTrips = Object.values(stats?.methods.commute || {}).reduce(
+            (sum, value) => sum + (value || 0),
+            0
+          );
+
+          return {
+            label: __routeId,
+            value: ((possibleConversions / allTrips) * 100).toFixed(2),
+          };
+        })}
+      />
+      <Statistic.Number
+        wrap
+        label="Current median commute time (all modes)"
+        unit="minutes"
+        data={futures.map(({ stats, __routeId }) => {
+          const medianDuration = stats?.median_duration.commute || 0;
+          return { label: __routeId, value: medianDuration.toFixed(2) };
+        })}
+      />
+      <SectionEntry
+        s={{ gridColumn: '1 / 3' }}
+        m={{ gridColumn: '1 / 4' }}
+        l={{ gridColumn: '1 / 5' }}
+      >
+        <div>
+          <Button href={'#/job-access' + search}>Explore industry/sector of employment</Button>
+        </div>
+      </SectionEntry>
+      <Statistic.Figure
+        wrap={{ f: { gridColumn: '1 / -1' } }}
+        label="Current commute travel modes"
+        legendBeforeTitle
+        plot={futures
+          .map(({ stats, __routeId, __label }) => {
+            return {
+              __label,
+              __routeId,
+              ...stats?.methods.commute,
+            };
+          })
+          .map(({ __label, __routeId, ...walkServiceAreaCurrentTravelMethods }) => {
+            const domainMap: Record<string, string> = {
+              biking: 'Biking',
+              carpool: 'Carpool',
+              commerical: 'Commercial',
+              on_demand_auto: 'Rideshare',
+              private_auto: 'Personal vehicle',
+              public_transit: 'Public transit',
+              walking: 'Walking',
+              other: 'Other',
+            };
+
+            return {
+              __label,
+              __routeId,
+              domainY: Object.values(domainMap),
+              plotData: toTidyNominal(domainMap)([walkServiceAreaCurrentTravelMethods]),
+            };
+          })
+          .map(({ __routeId, domainY, plotData }, index, array) => {
+            return (_, d3, { presets, utils }) => {
+              const allFacetsMaxX = utils.maxAcross(
+                array.flatMap(({ plotData }) => plotData),
+                'fraction'
+              );
+
+              const preset = presets.horizontalBar({
+                data: plotData,
+                domainX: [0, allFacetsMaxX],
+                domainY,
+                axis: {
+                  label: index === array.length - 1 ? 'Percent of commutes' : '',
+                  tickFormat: d3.format('.0%'),
+                },
+                x: 'fraction',
+                y: 'group',
+              });
+
+              return {
+                title: array.length > 1 ? __routeId : undefined,
+                ...preset,
+                color: {
+                  ...preset.color,
+                  legend: index === 0,
+                },
+              };
+            };
+          })}
+      />
+    </Section>,
+  ];
+}
+
+function Sidebar() {
+  const { scenarios } = useAppData();
+  const futureRouteIds = (scenarios.data?.futureRoutes || []).map((route) => route.__routeId);
+
+  return (
+    <SidebarContent>
+      <h1>Options</h1>
+
+      <h2>Filters</h2>
+      <SelectedFutureRoutes routeIds={futureRouteIds} />
+
+      <h2>Compare</h2>
+      <ComparisonModeSwitch />
+    </SidebarContent>
   );
 }

--- a/frontend/src/views/GeneralAccess.tsx
+++ b/frontend/src/views/GeneralAccess.tsx
@@ -577,7 +577,7 @@ function Sections() {
 
           return {
             label: area.__label,
-            value: (publicTransitTrips / allTrips).toFixed(2),
+            value: ((publicTransitTrips / allTrips) * 100).toFixed(2),
           };
         })}
       />


### PR DESCRIPTION
Also supports comparison mode. See the screenshot below for displayed stats. The map shows the selected future route, stops, and service areas. If multiple futures are selected, all selected routes, stops, and service areas are available on the map.

<img width="1076" height="701" alt="image" src="https://github.com/user-attachments/assets/b3b1561d-0a69-432d-8b64-580b60ef3b66" />
