### PR TITLE
feat(frontend): support showing job access for future routes on tab 3

### DIFF
--- a/frontend/src/components/common/Select/SelectedOption.tsx
+++ b/frontend/src/components/common/Select/SelectedOption.tsx
@@ -28,7 +28,7 @@ export function SelectedOption({
     <SelectedItemWrapper key={selectedOption.value}>
       <div className="select-item-detail">
         <div className="selected-item-label">{selectedOption.label}</div>
-        {showId ? (
+        {showId && selectedOption.id !== '‾‾supressId' ? (
           <div className="selected-item-id">{selectedOption.id || selectedOption.value}</div>
         ) : null}
       </div>
@@ -77,6 +77,7 @@ const SelectedItemWrapper = styled.div`
       flex-wrap: nowrap;
       word-break: break-word;
       position: relative;
+      white-space: pre-wrap;
     }
 
     .selected-item-id {

--- a/frontend/src/components/options/index.ts
+++ b/frontend/src/components/options/index.ts
@@ -1,5 +1,6 @@
 export * from './areas';
 export * from './compare';
 export * from './futures';
+export * from './job-access-areas';
 export * from './seasons';
 export { SelectTravelMethod } from './travel-method/SelectTravelMethod';

--- a/frontend/src/components/options/job-access-areas/SelectedJobAccessArea.tsx
+++ b/frontend/src/components/options/job-access-areas/SelectedJobAccessArea.tsx
@@ -1,0 +1,87 @@
+import { useSearchParams } from 'react-router';
+import { notEmpty } from '../../../utils';
+import { SelectMany, SelectOne } from '../../common';
+import { useComparisonModeState } from '../compare/useComparisonModeState';
+
+interface SelectedJobAccessAreaProps {
+  areasList: string[];
+  forceCompare?: boolean;
+}
+
+export function SelectedJobAccessArea({ areasList, forceCompare }: SelectedJobAccessAreaProps) {
+  const [_isComparing] = useComparisonModeState();
+  const isComparing = forceCompare || _isComparing;
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const currentSelectedAreas = searchParams.get('jobAreas')?.split(',').filter(notEmpty) || [];
+
+  const options = areasList
+    .map((value) => {
+      const [area, season] = value.split('::');
+      if (!area || !season) {
+        return null;
+      }
+
+      const seasonLabel: [string, string | undefined] = (() => {
+        if (season?.toLowerCase().includes('future')) {
+          return ['Future', undefined];
+        }
+
+        const quarter = season.split(':')[0] as 'Q2' | 'Q4';
+        const year = season.split(':')[1];
+        const label = `${year} ${quarter}`;
+
+        const monthRanges = {
+          Q2: 'April-June',
+          Q4: 'October-December',
+        };
+        const subLabel = `${monthRanges[quarter]}, ${year}`;
+
+        return [label, subLabel];
+      })();
+
+      const label = `${area} (${seasonLabel[0]})`;
+      const subLabel = seasonLabel[1] || '‾‾supressId';
+
+      return { label, value, id: subLabel };
+    })
+    .filter(notEmpty);
+
+  const selectedOptions = currentSelectedAreas
+    .map((area) => {
+      return options.find((option) => option.value === area);
+    })
+    .filter(notEmpty);
+
+  function handleChange(value: string | string[]) {
+    if (Array.isArray(value)) {
+      if (value.length === 0) {
+        searchParams.delete('jobAreas');
+      } else {
+        searchParams.set('jobAreas', value.join(','));
+      }
+    } else {
+      if (value === '') {
+        searchParams.delete('jobAreas');
+      } else {
+        searchParams.set('jobAreas', value);
+      }
+    }
+    setSearchParams(searchParams);
+  }
+
+  return (
+    <div>
+      <label>Area{isComparing ? 's' : ''}</label>
+      {isComparing ? (
+        <SelectMany options={options} onChange={handleChange} selectedOptions={selectedOptions} />
+      ) : (
+        <SelectOne
+          onChange={handleChange}
+          options={options}
+          value={selectedOptions[0]?.value || ''}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/options/job-access-areas/index.ts
+++ b/frontend/src/components/options/job-access-areas/index.ts
@@ -1,0 +1,1 @@
+export { SelectedJobAccessArea } from './SelectedJobAccessArea';

--- a/frontend/src/hooks/useAppData.ts
+++ b/frontend/src/hooks/useAppData.ts
@@ -125,6 +125,9 @@ function _useAppData({ areas, seasons, travelMethod }: AppDataHookParameters) {
                 .filter((item) => !!item.NAME)
                 // omit items that do not belong to the current area
                 .filter((item) => item.areas.includes(area));
+              if (areaData.length === 0) {
+                return null;
+              }
 
               // group the data by YEAR
               const groupedData = Object.entries(Object.groupBy(areaData, (d) => d.YEAR))

--- a/frontend/src/views/FutureOpportunities.tsx
+++ b/frontend/src/views/FutureOpportunities.tsx
@@ -89,6 +89,12 @@ function Sections() {
     selectedRouteIds.includes(future.__routeId)
   );
 
+  const jobAccessSearch = (() => {
+    const currentSearchParams = new URLSearchParams(search);
+    currentSearchParams.set('jobAreas', selectedRouteIds.map((id) => `${id}::future`).join(','));
+    return currentSearchParams.toString() ? `?${currentSearchParams.toString()}` : '';
+  })();
+
   return [
     <Section title="Coverage">
       <Statistic.Number
@@ -178,7 +184,9 @@ function Sections() {
         l={{ gridColumn: '1 / 5' }}
       >
         <div>
-          <Button href={'#/job-access' + search}>Explore industry/sector of employment</Button>
+          <Button href={'#/job-access' + jobAccessSearch}>
+            Explore industry/sector of employment
+          </Button>
         </div>
       </SectionEntry>
       <Statistic.Figure

--- a/frontend/src/views/GeneralAccess.tsx
+++ b/frontend/src/views/GeneralAccess.tsx
@@ -79,6 +79,20 @@ function Sections() {
 
   const ridershipDataExists = data?.some((area) => area.ridership) || false;
 
+  const jobAccessSearch = (() => {
+    const currentSearchParams = new URLSearchParams(search);
+
+    const selectedAreas = currentSearchParams.get('areas')?.split(',').filter(notEmpty) || [];
+    const selectedSeasons = currentSearchParams.get('seasons')?.split(',').filter(notEmpty) || [];
+
+    const selectedSeasonAreas = selectedAreas.flatMap((area) => {
+      return selectedSeasons.map((season) => `${area}::${season}`);
+    });
+
+    currentSearchParams.set('jobAreas', selectedSeasonAreas.join(','));
+    return currentSearchParams.toString() ? `?${currentSearchParams.toString()}` : '';
+  })();
+
   return [
     <DeveloperDetails data={data} />,
     <Section title="Service Statistics">
@@ -631,7 +645,9 @@ function Sections() {
         l={{ gridColumn: '1 / 5' }}
       >
         <div>
-          <Button href={'#/job-access' + search}>Explore industry/sector of employment</Button>
+          <Button href={'#/job-access' + jobAccessSearch}>
+            Explore industry/sector of employment
+          </Button>
         </div>
       </SectionEntry>
     </Section>,

--- a/frontend/src/views/JobAccess.tsx
+++ b/frontend/src/views/JobAccess.tsx
@@ -1,8 +1,9 @@
 import styled from '@emotion/styled';
 import * as d3 from 'd3';
+import { useSearchParams } from 'react-router';
 import { CoreFrame, Section, SidebarContent, TreeMap } from '../components';
 import { AppNavigation } from '../components/navigation';
-import { ComparisonModeSwitch, SelectedArea, SelectedSeason } from '../components/options';
+import { SelectedJobAccessArea } from '../components/options';
 import { useAppData } from '../hooks';
 import { notEmpty } from '../utils';
 
@@ -43,7 +44,84 @@ function Sections() {
 }
 
 function useJobData() {
-  const { data } = useAppData();
+  const { data, scenarios } = useAppData();
+
+  const [searchParams] = useSearchParams();
+  const selectedRouteIds = (searchParams.get('jobAreas')?.split(',').filter(notEmpty) || [])
+    .filter((jobArea) => jobArea.toLowerCase().includes('future'))
+    .map((value) => value.split('::')[0])
+    .filter(notEmpty);
+  const futures = (scenarios.data?.futureRoutes || []).filter((future) =>
+    selectedRouteIds.includes(future.__routeId)
+  );
+
+  function toJobData(
+    data: [
+      { __label: string },
+      {
+        type_counts: ReplicaDesinationUseTypeStatistics;
+        subtype_counts: ReplicaDesinationUseSubTypeStatistics;
+      }
+    ]
+  ) {
+    const [{ __label }, { type_counts, subtype_counts }] = data;
+
+    return {
+      name: __label,
+      children: [
+        {
+          name: 'Transportation Utilities',
+          value: type_counts?.transportation_utilities || 0,
+        },
+        {
+          name: 'Other',
+          value: type_counts?.other || 0,
+        },
+        {
+          name: 'Industrial',
+          value: type_counts?.industrial || 0,
+        },
+        {
+          name: 'Commercial',
+          children: [
+            {
+              name: 'Retail',
+              value: subtype_counts?.retail || 0,
+            },
+            {
+              name: 'Office',
+              value: subtype_counts?.office || 0,
+            },
+            {
+              name: 'Non-Retail Attraction',
+              value: subtype_counts?.non_retail_attraction || 0,
+            },
+          ],
+        },
+        {
+          name: 'Civic Institutional',
+          children: [
+            {
+              name: 'Other Civic Institutional',
+              value: subtype_counts?.civic_institutional || 0,
+            },
+            {
+              name: 'Education',
+              value: subtype_counts?.education || 0,
+            },
+            {
+              name: 'Healthcare',
+              value: subtype_counts?.healthcare || 0,
+            },
+          ],
+        },
+        {
+          name: 'Agriculture',
+          value: type_counts?.agriculture || 0,
+        },
+      ],
+    };
+  }
 
   const jobDataByArea = (data || [])
     .map(({ __area, __quarter, __year, __label, statistics }) => {
@@ -53,72 +131,33 @@ function useJobData() {
       ] as const;
     })
     .filter((x): x is [(typeof x)[0], NonNullable<(typeof x)[1]>] => notEmpty(x[1]))
-    .map(([{ __label }, { type_counts, subtype_counts }]) => {
-      return {
-        name: __label,
-        children: [
-          {
-            name: 'Transportation Utilities',
-            value: type_counts?.transportation_utilities || 0,
-          },
-          {
-            name: 'Other',
-            value: type_counts?.other || 0,
-          },
-          {
-            name: 'Industrial',
-            value: type_counts?.industrial || 0,
-          },
-          {
-            name: 'Commercial',
-            children: [
-              {
-                name: 'Retail',
-                value: subtype_counts?.retail || 0,
-              },
-              {
-                name: 'Office',
-                value: subtype_counts?.office || 0,
-              },
-              {
-                name: 'Non-Retail Attraction',
-                value: subtype_counts?.non_retail_attraction || 0,
-              },
-            ],
-          },
-          {
-            name: 'Civic Institutional',
-            children: [
-              {
-                name: 'Other Civic Institutional',
-                value: subtype_counts?.civic_institutional || 0,
-              },
-              {
-                name: 'Education',
-                value: subtype_counts?.education || 0,
-              },
-              {
-                name: 'Healthcare',
-                value: subtype_counts?.healthcare || 0,
-              },
-            ],
-          },
-          {
-            name: 'Agriculture',
-            value: type_counts?.agriculture || 0,
-          },
-        ],
-      };
-    });
+    .map(toJobData);
+
+  const futureJobDataByArea = futures
+    .map(({ __label, stats }) => {
+      const viaWalk = stats?.destination_building_use?.via_walk;
+      if (!viaWalk) {
+        return null;
+      }
+
+      return [{ __label }, viaWalk] as [
+        { __label: string },
+        NonNullable<NonNullable<FutureRouteStatistics['destination_building_use']>['via_walk']>
+      ];
+    })
+    .filter(notEmpty)
+    .map(toJobData);
+
+  const combinedJobData = [...jobDataByArea, ...futureJobDataByArea];
 
   const domain =
-    jobDataByArea[0]?.children.map((d) => d.name).sort((a, b) => a.localeCompare(b)) || [];
+    combinedJobData[0]?.children.map((d) => d.name).sort((a, b) => a.localeCompare(b)) || [];
   const colorScheme = [
     ...d3.schemeObservable10.slice(0, 6).toReversed(),
     ...d3.schemeObservable10.slice(6),
   ];
 
-  return { jobDataByArea, domain, colorScheme };
+  return { jobDataByArea: combinedJobData, domain, colorScheme };
 }
 
 interface HeaderProps {}
@@ -189,18 +228,22 @@ const HeaderComponent = styled.div<HeaderProps>`
 `;
 
 function Sidebar() {
-  const { areasList, seasonsList } = useAppData();
+  const { areasList, seasonsList, scenarios } = useAppData();
+  const futureRouteIds = (scenarios.data?.futureRoutes || []).map((future) => future.__routeId);
+
+  const jobAccessAreasList = [
+    areasList.flatMap((area) => {
+      return seasonsList.map((season) => `${area}::${season}`);
+    }),
+    futureRouteIds.map((futureRouteId) => `${futureRouteId}::future`),
+  ].flat();
 
   return (
     <SidebarContent>
       <h1>Options</h1>
 
       <h2>Filters</h2>
-      <SelectedArea areasList={areasList} />
-      <SelectedSeason seasonsList={seasonsList} />
-
-      <h2>Compare</h2>
-      <ComparisonModeSwitch />
+      <SelectedJobAccessArea areasList={jobAccessAreasList} />
     </SidebarContent>
   );
 }


### PR DESCRIPTION
This change decouples the areas on tab 3 from the areas on tabs 1 and 4.

Now, tab 3 can show season-areas (like before) and future routes (new). They are stored in the URL as `jobAreas`, where season-areas are in the format `areaName::QX::YYYY` and future routes are stored in the format `futureRouteId::future`.