### PR TITLE
fix(frontend): restore the gap between job access tree maps on tab 3

### DIFF
--- a/frontend/src/views/JobAccess.tsx
+++ b/frontend/src/views/JobAccess.tsx
@@ -14,6 +14,7 @@ export function JobAccess() {
       sectionsStyle={{
         display: 'grid',
         gridTemplateColumns: 'repeat(auto-fit, minmax(clamp(300px, 100%, 600px), 1fr))',
+        gap: '0.5rem 1rem',
         gridAutoRows: 'minmax(200px, 1fr)',
       }}
       header={<AppNavigation />}


### PR DESCRIPTION
The gap was lost when we changed the CoreFrame to use columns instead of grid. This restores the gap to tab 3, which already replaces the columns with a grid for its layout.