### PR TITLE
feat(frontend): add commas to number statistics when appropriate

### DIFF
--- a/frontend/src/components/common/Statistic/Number.tsx
+++ b/frontend/src/components/common/Statistic/Number.tsx
@@ -64,14 +64,14 @@ export function Number(props: NumberProps) {
               return (
                 <React.Fragment key={label + index}>
                   <span role="cell">{label}</span>
-                  <span role="cell">{value}</span>
+                  <span role="cell">{value.toLocaleString()}</span>
                 </React.Fragment>
               );
             })}
           </div>
         ) : (
           <div className="single-value">
-            {data}
+            {data.toLocaleString()}
             {props.unit ? <span className="unit"> {props.unit}</span> : null}
           </div>
         )}


### PR DESCRIPTION
Example:

<img width="283" height="167" alt="image" src="https://github.com/user-attachments/assets/44a561b1-fc7e-4e16-a7e5-0ca778bba5ba" />
