### PR TITLE
fix(frontend): use correct denominator for "Trips that could use public transit"

### DIFF
--- a/frontend/src/views/FutureOpportunities.tsx
+++ b/frontend/src/views/FutureOpportunities.tsx
@@ -158,7 +158,7 @@ function Sections() {
         label="Trips that could use public transit"
         data={futures.map(({ stats, __routeId }) => {
           const possibleConversions = stats?.possible_conversions.via_walk || 0;
-          const allTrips = Object.values(stats?.methods.commute || {}).reduce(
+          const allTrips = Object.values(stats?.methods.__all || {}).reduce(
             (sum, value) => sum + (value || 0),
             0
           );

--- a/frontend/src/views/GeneralAccess.tsx
+++ b/frontend/src/views/GeneralAccess.tsx
@@ -615,9 +615,10 @@ function Sections() {
         data={data?.map((area) => {
           const possibleConversions =
             area.statistics?.thursday_trip.possible_conversions.via_walk || 0;
-          const allTrips = Object.values(
-            area.statistics?.thursday_trip.methods.commute || {}
-          ).reduce((sum, value) => sum + (value || 0), 0);
+          const allTrips = Object.values(area.statistics?.thursday_trip.methods.__all || {}).reduce(
+            (sum, value) => sum + (value || 0),
+            0
+          );
 
           return {
             label: area.__label,


### PR DESCRIPTION
The the `allTrip` sum was only using commute, but it should be all travel types.