### PR TITLE
fix(frontend): force job access area selector to always use comparison mode (`SelectMany`)

### DIFF
--- a/frontend/src/views/JobAccess.tsx
+++ b/frontend/src/views/JobAccess.tsx
@@ -244,7 +244,7 @@ function Sidebar() {
       <h1>Options</h1>
 
       <h2>Filters</h2>
-      <SelectedJobAccessArea areasList={jobAccessAreasList} />
+      <SelectedJobAccessArea areasList={jobAccessAreasList} forceCompare />
     </SidebarContent>
   );
 }


### PR DESCRIPTION
Resolves #106