### PR TITLE
fix(pipeline/essential_services): do not crash when trip folders are missing

### DIFF
--- a/data-pipeline/src/etl/sources/essential_services/etl.py
+++ b/data-pipeline/src/etl/sources/essential_services/etl.py
@@ -206,7 +206,11 @@ class EssentialServicesETL:
         """
         Generator that yields paths to trip data files for a given area and day for each season in the south atlantic region.
         """
-        season_folders = [path for path in (area / f'{day}_trip').iterdir() if path.is_dir()]
+        trip_folder = area / f'{day}_trip'
+        if not trip_folder.exists():
+            return
+
+        season_folders = [path for path in trip_folder.iterdir() if path.is_dir()]
         seasons = [path.name[-7:len(path.name)] for path in season_folders]
 
         if season is not None:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,8 @@
     "data": "node beforeStart.js",
     "lint": "eslint .",
     "preview": "vite preview",
-    "zipdist": "tar --create --use-compress-program=pigz --file dist.tar.gz dist && rm -rf dist && mkdir dist && mv dist.tar.gz dist/"
+    "zipdist": "tar --create --use-compress-program=pigz --file dist.tar.gz dist && rm -rf dist && mkdir dist && mv dist.tar.gz dist/",
+    "zipdata": "tar --create --use-compress-program=pigz --file data.tar.gz public"
   },
   "dependencies": {
     "@arcgis/map-components": "^4.33.2",


### PR DESCRIPTION
Instead, skip the folder.