### PR TITLE
feat(frontend): show simplified options for areas and seasons at the top of tab sections (tabs 1, 2 and 4)

### DIFF
--- a/frontend/src/components/layout/CoreFrame/CoreFrame.tsx
+++ b/frontend/src/components/layout/CoreFrame/CoreFrame.tsx
@@ -1,6 +1,5 @@
 import styled from '@emotion/styled';
-import { useContext, useRef, useState } from 'react';
-import { useRect } from '../../../hooks';
+import { useContext, useEffect, useRef, useState } from 'react';
 import { Tab } from '../../common';
 import { CoreFrameContext } from './CoreFrameContext';
 import { SidebarWrapper } from './SidebarWrapper';
@@ -27,14 +26,14 @@ interface CoreFrameProps {
 
 export function CoreFrame(props: CoreFrameProps) {
   const containerRef = useRef<HTMLDivElement>(null);
-  const { width } = useRect(containerRef);
-
-  const isMobile = width < 900;
-  const isFullDesktop = width >= 1280;
 
   const [activeMobileSection, setActiveMobileSection] = useState(0);
 
-  const { fixedSidebarOpen } = useContext(CoreFrameContext);
+  const { fixedSidebarOpen, setContainerRef, isMobile, isFullDesktop, width } =
+    useContext(CoreFrameContext);
+  useEffect(() => {
+    setContainerRef(containerRef);
+  }, [containerRef]);
 
   return (
     <Container ref={containerRef}>

--- a/frontend/src/components/layout/CoreFrame/CoreFrameContext.ts
+++ b/frontend/src/components/layout/CoreFrame/CoreFrameContext.ts
@@ -1,4 +1,5 @@
-import { createContext, useCallback, useState } from 'react';
+import { createContext, RefObject, useCallback, useState } from 'react';
+import { useRect } from '../../../hooks';
 
 export interface CoreFrameContextValue {
   optionsOpen: boolean;
@@ -8,9 +9,21 @@ export interface CoreFrameContextValue {
   fixedSidebarOpen: boolean;
   setOptionsOpen: (open: boolean) => void;
   setForceClosed: (forceClosed: boolean) => void;
+  setContainerRef: (ref: RefObject<HTMLDivElement | null>) => void;
+  isMobile: boolean;
+  isFullDesktop: boolean;
+  width: number;
 }
 
 export function createCoreFrameContextValue(): CoreFrameContextValue {
+  const [containerRef, setContainerRef] = useState<RefObject<HTMLDivElement | null>>({
+    current: null,
+  });
+  const { width } = useRect(containerRef);
+
+  const isMobile = width < 900;
+  const isFullDesktop = width >= 1280;
+
   // sidebar-related state
   const [optionsOpen, _setOptionsOpen] = useState(false);
   const setOptionsOpen = useCallback((bool: boolean) => {
@@ -64,6 +77,10 @@ export function createCoreFrameContextValue(): CoreFrameContextValue {
     setOptionsOpen,
     setForceClosed,
     fixedSidebarOpen,
+    setContainerRef,
+    isMobile,
+    isFullDesktop,
+    width,
   };
 }
 

--- a/frontend/src/components/layout/PageHeader/PageHeader.tsx
+++ b/frontend/src/components/layout/PageHeader/PageHeader.tsx
@@ -1,8 +1,8 @@
 import styled from '@emotion/styled';
 
-export const PageHeader = styled.div`
+export const PageHeader = styled.div<{ isComparing?: boolean }>`
   text-align: center;
-  padding: 0.5rem 0.5rem 1rem 0.5rem;
+  padding: 0.5rem 0 1rem 0;
   border-bottom: 1px solid lightgray;
   @container core (max-width: 899px) {
     padding: 0rem 0.5rem;
@@ -31,6 +31,45 @@ export const PageHeader = styled.div`
     @container core (max-width: 899px) {
       font-size: 13px;
       margin: 0.25rem 0;
+    }
+  }
+
+  // button row
+  .button-row {
+    display: flex;
+    flex-direction: row;
+    text-align: left;
+    gap: 0.5rem;
+
+    // justfy so that the more options button is always in the bottom right
+    // (bottom for alighnment with select elements, right for consistency)
+    align-items: end;
+    justify-content: end;
+
+    // add spacing and a border to separate from the content above
+    border-top: 1px solid lightgray;
+    margin-top: 1rem;
+    padding-top: ${({ isComparing }) => (isComparing ? 1 : 0.5)}rem;
+
+    > div {
+      // allow form elements to grow to fill available space
+      flex-grow: 1;
+
+      // use smaller labels for the select element labels
+      label {
+        font-size: 0.875rem;
+      }
+    }
+
+    p.message {
+      flex.grow: 1;
+      text-align: left;
+      margin: 0;
+      font-size: 0.875rem;
+      line-height: 1.2;
+      color: var(--text-secondary);
+      align-self: center;
+      width: 100%;
     }
   }
 `;

--- a/frontend/src/views/EssentialServicesAccess.tsx
+++ b/frontend/src/views/EssentialServicesAccess.tsx
@@ -1,12 +1,22 @@
 import '@arcgis/map-components/dist/components/arcgis-map';
-import { useState } from 'react';
-import { CoreFrame, Map, PageHeader, Section, SidebarContent, Statistic } from '../components';
+import { useContext, useState } from 'react';
+import {
+  Button,
+  CoreFrame,
+  CoreFrameContext,
+  Map,
+  PageHeader,
+  Section,
+  SidebarContent,
+  Statistic,
+} from '../components';
 import { AppNavigation } from '../components/navigation';
 import {
   ComparisonModeSwitch,
   SelectedArea,
   SelectedSeason,
   SelectTravelMethod,
+  useComparisonModeState,
 } from '../components/options';
 import { useAppData, useMapData } from '../hooks';
 import { notEmpty } from '../utils';
@@ -71,13 +81,31 @@ export function EssentialServicesAccess() {
 }
 
 function SectionsHeader() {
+  const [isComparing] = useComparisonModeState();
+  const { areasList, seasonsList } = useAppData();
+
+  const { optionsOpen, setOptionsOpen, isFullDesktop, isMobile } = useContext(CoreFrameContext);
+
   return (
-    <PageHeader>
+    <PageHeader isComparing={isComparing}>
       <h2>Which essential services can you access via public transit?</h2>
       <p>
         Learn what percentage of the population can reach essential services via public transit and
         how long it takes.
       </p>
+      {isFullDesktop || isMobile ? null : (
+        <div className="button-row">
+          {isComparing ? (
+            <p className="message">Open options to show different areas and seasons.</p>
+          ) : (
+            <>
+              <SelectedArea areasList={areasList} />
+              <SelectedSeason seasonsList={seasonsList} />
+            </>
+          )}
+          <Button onClick={() => setOptionsOpen(!optionsOpen)}>More options</Button>
+        </div>
+      )}
     </PageHeader>
   );
 }

--- a/frontend/src/views/FutureOpportunities.tsx
+++ b/frontend/src/views/FutureOpportunities.tsx
@@ -1,9 +1,10 @@
 import '@arcgis/map-components/dist/components/arcgis-map';
-import { useState } from 'react';
+import { useContext, useState } from 'react';
 import { useLocation, useSearchParams } from 'react-router';
 import {
   Button,
   CoreFrame,
+  CoreFrameContext,
   Map,
   PageHeader,
   Section,
@@ -82,10 +83,26 @@ export function FutureOpportunities() {
 }
 
 function SectionsHeader() {
+  const [isComparing] = useComparisonModeState();
+  const { scenarios } = useAppData();
+  const futureRouteIds = (scenarios.data?.futureRoutes || []).map((route) => route.__routeId);
+
+  const { optionsOpen, setOptionsOpen, isFullDesktop, isMobile } = useContext(CoreFrameContext);
+
   return (
-    <PageHeader>
+    <PageHeader isComparing={isComparing}>
       <h2>Future Transit Routes & Stops</h2>
       <p>Visualize selected future transit routes from Greenlink's transit development plan.</p>
+      {isFullDesktop || isMobile ? null : (
+        <div className="button-row">
+          {isComparing ? (
+            <p className="message">Open options to show different routes.</p>
+          ) : (
+            <SelectedFutureRoutes routeIds={futureRouteIds} />
+          )}
+          <Button onClick={() => setOptionsOpen(!optionsOpen)}>More options</Button>
+        </div>
+      )}
     </PageHeader>
   );
 }

--- a/frontend/src/views/GeneralAccess.tsx
+++ b/frontend/src/views/GeneralAccess.tsx
@@ -1,9 +1,10 @@
 import '@arcgis/map-components/dist/components/arcgis-map';
-import { useState } from 'react';
+import { useContext, useState } from 'react';
 import { useLocation } from 'react-router';
 import {
   Button,
   CoreFrame,
+  CoreFrameContext,
   DeveloperDetails,
   ErrorBoundary,
   Map,
@@ -19,6 +20,7 @@ import {
   SelectedArea,
   SelectedSeason,
   SelectTravelMethod,
+  useComparisonModeState,
 } from '../components/options';
 import { useAppData, useMapData } from '../hooks';
 import { listOxford, notEmpty, requireKey, toTidyNominal } from '../utils';
@@ -68,12 +70,29 @@ export function GeneralAccess() {
 }
 
 function SectionsHeader() {
-  const { data } = useAppData();
+  const [isComparing] = useComparisonModeState();
+  const { data, areasList, seasonsList } = useAppData();
+
+  const { optionsOpen, setOptionsOpen, isFullDesktop, isMobile } = useContext(CoreFrameContext);
+
   const uniqueAreaNames = Array.from(new Set((data || []).map((area) => area.__area))).sort();
 
   return (
-    <PageHeader>
+    <PageHeader isComparing={isComparing}>
       <h2>{listOxford(uniqueAreaNames)}</h2>
+      {isFullDesktop || isMobile ? null : (
+        <div className="button-row">
+          {isComparing ? (
+            <p className="message">Open options to show different areas and seasons.</p>
+          ) : (
+            <>
+              <SelectedArea areasList={areasList} />
+              <SelectedSeason seasonsList={seasonsList} />
+            </>
+          )}
+          <Button onClick={() => setOptionsOpen(!optionsOpen)}>More options</Button>
+        </div>
+      )}
     </PageHeader>
   );
 }


### PR DESCRIPTION
This makes it easier to quickly change options when in desktop mode and the screen is not wide enough to show the sidebar in a fixed position. These new options only appear when the device is in the desktop view that is between mobile mode and fixed-sidebar mode.

Closes #136

Comparison mode disabled
<img width="1076" height="369" alt="image" src="https://github.com/user-attachments/assets/d0151c74-f7dc-4555-b6ec-2554897b0a43" />

Comparison mode enabled
<img width="1077" height="395" alt="image" src="https://github.com/user-attachments/assets/69f39fc1-04e6-4cc4-bdc4-575826339dd5" />
