### PR TITLE
feat(frontend): show loading indicators and overlay when data is downloading

### DIFF
--- a/frontend/src/components/common/ProgressRing/ProgressRing.tsx
+++ b/frontend/src/components/common/ProgressRing/ProgressRing.tsx
@@ -1,0 +1,52 @@
+import { keyframes } from '@emotion/react';
+import styled from '@emotion/styled';
+import React from 'react';
+
+interface ProgressRingProps {
+  size?: number;
+}
+
+export const ProgressRing: React.FC<ProgressRingProps> = ({ size = 32 }) => {
+  return (
+    <StyledSvg
+      className="progress-ring indeterminate"
+      width={size}
+      height={size}
+      viewBox="0 0 16 16"
+      role="status"
+    >
+      <circle cx="50%" cy="50%" r="7" strokeDasharray="3" strokeDashoffset="NaN" />
+    </StyledSvg>
+  );
+};
+
+const progressRingAnimation = keyframes`
+  0% {
+    stroke-dasharray: 0.01px 43.97px;
+    transform: rotate(0);
+  }
+
+  50% {
+    stroke-dasharray: 21.99px 21.99px;
+    transform: rotate(450deg);
+  }
+
+  100% {
+    stroke-dasharray: 0.01px 43.97px;
+    transform: rotate(3turn);
+  }
+`;
+
+const StyledSvg = styled.svg`
+  circle {
+    fill: none;
+    stroke: var(--color-primary);
+    stroke-width: 1.5;
+    stroke-linecap: round;
+    stroke-dasharray: 43.97;
+    transform: rotate(-90deg);
+    transform-origin: 50% 50%;
+    transition: all var(--wui-control-normal-duration) linear;
+    animation: ${progressRingAnimation} 2s linear infinite;
+  }
+`;

--- a/frontend/src/components/common/index.ts
+++ b/frontend/src/components/common/index.ts
@@ -5,6 +5,7 @@ export { IconButton } from './IconButton/IconButton';
 export { Map } from './Map/Map';
 export { NavBar } from './NavBarItem/NavBar';
 export { NavBarItem } from './NavBarItem/NavBarItem';
+export { ProgressRing } from './ProgressRing/ProgressRing';
 export { Section } from './Section/Section';
 export { SectionEntry } from './Section/SectionEntry';
 export { SelectMany } from './Select/SelectMany';

--- a/frontend/src/components/layout/CoreFrame/CoreFrame.tsx
+++ b/frontend/src/components/layout/CoreFrame/CoreFrame.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import { useContext, useEffect, useRef, useState } from 'react';
-import { Tab } from '../../common';
+import { ProgressRing, Tab } from '../../common';
 import { CoreFrameContext } from './CoreFrameContext';
 import { SidebarWrapper } from './SidebarWrapper';
 
@@ -22,6 +22,9 @@ interface CoreFrameProps {
 
   /** disables columns for the sections area */
   disableSectionColumns?: boolean;
+
+  /** Shows a loading indicator and a scrim that covers the content underneath. */
+  loading?: boolean;
 }
 
 export function CoreFrame(props: CoreFrameProps) {
@@ -34,6 +37,18 @@ export function CoreFrame(props: CoreFrameProps) {
   useEffect(() => {
     setContainerRef(containerRef);
   }, [containerRef]);
+
+  const [loadingDelayed, setLoadingDelayed] = useState(false);
+  useEffect(() => {
+    if (props.loading) {
+      const timeout = setTimeout(() => {
+        setLoadingDelayed(true);
+      }, 500);
+      return () => clearTimeout(timeout);
+    }
+
+    setLoadingDelayed(false);
+  }, [props.loading]);
 
   return (
     <Container ref={containerRef}>
@@ -65,7 +80,7 @@ export function CoreFrame(props: CoreFrameProps) {
                     );
                   })}
               </div>
-              <MainAreaWrapper style={{ padding: '1rem' }}>
+              <MainAreaWrapper>
                 {props.sectionsHeader}
                 <MainArea
                   disableSectionColumns={props.disableSectionColumns}
@@ -92,6 +107,28 @@ export function CoreFrame(props: CoreFrameProps) {
           {props.sidebar ? (
             <SidebarWrapper frameWidth={width}>{props.sidebar}</SidebarWrapper>
           ) : null}
+          <div
+            key="loading"
+            style={{
+              position: 'absolute',
+              inset: 0,
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: '1rem',
+              zIndex: loadingDelayed ? 10 : -1,
+              opacity: loadingDelayed ? 1 : 0,
+              backgroundColor: '#ffffff77',
+              backdropFilter: 'blur(14px)',
+              transition: 'opacity 300ms cubic-bezier(0.16, 1, 0.3, 1)',
+              fontSize: '1rem',
+              fontWeight: 500,
+            }}
+          >
+            <ProgressRing size={32} />
+            Downloading data
+          </div>
         </InnerFrame>
       </OuterFrame>
     </Container>
@@ -138,6 +175,8 @@ const InnerFrame = styled.div<{ fixedSidebarOpen: boolean; hasMapElement?: boole
   // gap: 1rem;
 
   transition: 120ms;
+
+  position: relative;
 
   @container core (min-width: 1280px) {
     padding-right: ${({ fixedSidebarOpen }) => (fixedSidebarOpen ? '1rem' : '0')};

--- a/frontend/src/hooks/useAppData.ts
+++ b/frontend/src/hooks/useAppData.ts
@@ -280,28 +280,26 @@ function _useAppData({ areas, seasons, travelMethod }: AppDataHookParameters) {
     const abortController = new AbortController();
     const { signal } = abortController;
 
-    if (loading === false) {
-      setLoading(true);
-      setErrors(null);
-      resolveArrayOfPromiseRecords(dataPromises, signal)
-        .then((fetchedData) => {
-          if (fetchedData) {
-            setData(fetchedData);
-          }
-        })
-        .catch((error) => {
-          if (!signal.aborted) {
-            setErrors((prevErrors) => (prevErrors ? [...prevErrors, error] : [error]));
-            console.error('An error occurred while fetching data. Please try again later.', error);
-          }
-          return null;
-        })
-        .finally(() => {
-          if (!signal.aborted) {
-            setLoading(false);
-          }
-        });
-    }
+    setLoading(true);
+    setErrors(null);
+    resolveArrayOfPromiseRecords(dataPromises, signal)
+      .then((fetchedData) => {
+        if (fetchedData) {
+          setData(fetchedData);
+        }
+      })
+      .catch((error) => {
+        if (!signal.aborted) {
+          setErrors((prevErrors) => (prevErrors ? [...prevErrors, error] : [error]));
+          console.error('An error occurred while fetching data. Please try again later.', error);
+        }
+        return null;
+      })
+      .finally(() => {
+        if (!signal.aborted) {
+          setLoading(false);
+        }
+      });
 
     return () => {
       abortController.abort('fetch effect in useAppData is being cleaned up');
@@ -326,35 +324,33 @@ function _useAppData({ areas, seasons, travelMethod }: AppDataHookParameters) {
     const { signal } = abortController;
 
     const scenarioDataPromises = constructScenarioDataPromises(scenariosList);
-    if (scenarioLoading === false && scenarioDataPromises) {
-      setScenarioLoading(true);
-      setScenarioErrors(null);
+    setScenarioLoading(true);
+    setScenarioErrors(null);
 
-      const { futureRoutes, ...rest } = scenarioDataPromises;
+    const { futureRoutes, ...rest } = scenarioDataPromises;
 
-      const resolvedScenarios = resolveObjectOfPromises(rest, signal);
-      const resolvedFutureRoutes = resolveArrayOfPromiseRecords(futureRoutes, signal);
+    const resolvedScenarios = resolveObjectOfPromises(rest, signal);
+    const resolvedFutureRoutes = resolveArrayOfPromiseRecords(futureRoutes, signal);
 
-      Promise.all([resolvedScenarios, resolvedFutureRoutes])
-        .then((fetchedData) => {
-          const [scenariosData, futureRoutesData] = fetchedData;
-          if (scenariosData && futureRoutesData) {
-            setScenarioData({ ...scenariosData, futureRoutes: futureRoutesData });
-          }
-        })
-        .catch((error) => {
-          if (!signal.aborted) {
-            setScenarioErrors((prevErrors) => (prevErrors ? [...prevErrors, error] : [error]));
-            console.error('An error occurred while fetching scenario data.', error);
-          }
-          return null;
-        })
-        .finally(() => {
-          if (!signal.aborted) {
-            setScenarioLoading(false);
-          }
-        });
-    }
+    Promise.all([resolvedScenarios, resolvedFutureRoutes])
+      .then((fetchedData) => {
+        const [scenariosData, futureRoutesData] = fetchedData;
+        if (scenariosData && futureRoutesData) {
+          setScenarioData({ ...scenariosData, futureRoutes: futureRoutesData });
+        }
+      })
+      .catch((error) => {
+        if (!signal.aborted) {
+          setScenarioErrors((prevErrors) => (prevErrors ? [...prevErrors, error] : [error]));
+          console.error('An error occurred while fetching scenario data.', error);
+        }
+        return null;
+      })
+      .finally(() => {
+        if (!signal.aborted) {
+          setScenarioLoading(false);
+        }
+      });
 
     return () => {
       abortController.abort('fetch effect in useAppData for scenario data is being cleaned up');
@@ -368,6 +364,7 @@ function _useAppData({ areas, seasons, travelMethod }: AppDataHookParameters) {
     areasList,
     seasonsList,
     travelMethodList,
+    scenariosList,
     scenarios: {
       data: scenarioData,
       loading: scenarioLoading,

--- a/frontend/src/views/EssentialServicesAccess.tsx
+++ b/frontend/src/views/EssentialServicesAccess.tsx
@@ -22,7 +22,7 @@ import { useAppData, useMapData } from '../hooks';
 import { notEmpty } from '../utils';
 
 export function EssentialServicesAccess() {
-  const { data } = useAppData();
+  const { data, loading } = useAppData();
 
   const [mapView, setMapView] = useState<__esri.MapView | null>(null);
   const {
@@ -46,6 +46,7 @@ export function EssentialServicesAccess() {
   return (
     <CoreFrame
       outerStyle={{ height: '100%' }}
+      loading={loading}
       header={<AppNavigation />}
       sectionsHeader={<SectionsHeader />}
       sidebar={<Sidebar />}
@@ -111,7 +112,23 @@ function SectionsHeader() {
 }
 
 function Sections() {
-  const { data } = useAppData();
+  const { data, loading, errors } = useAppData();
+
+  if (loading && !data) {
+    return [
+      <div key="placeholder-loading">
+        <p>Loading...</p>
+      </div>,
+    ];
+  }
+
+  if (errors) {
+    return [
+      <div key="placeholder-error">
+        <p>Error: {errors.join(', ')}</p>
+      </div>,
+    ];
+  }
 
   return [
     <Section title="Essential Services Access via Public Transit" key={0}>

--- a/frontend/src/views/FutureOpportunities.tsx
+++ b/frontend/src/views/FutureOpportunities.tsx
@@ -23,7 +23,7 @@ import { useFutureMapData } from '../hooks/useMapData';
 import { notEmpty, toTidyNominal } from '../utils';
 
 export function FutureOpportunities() {
-  const { data, scenarios: scenariosData } = useAppData();
+  const { data, scenarios: scenariosData, loading } = useAppData();
 
   const [isComparing] = useComparisonModeState();
   const [searchParams] = useSearchParams();
@@ -52,6 +52,7 @@ export function FutureOpportunities() {
   return (
     <CoreFrame
       outerStyle={{ height: '100%' }}
+      loading={loading || scenariosData.loading}
       header={<AppNavigation />}
       sectionsHeader={<SectionsHeader />}
       sidebar={<Sidebar />}
@@ -108,8 +109,8 @@ function SectionsHeader() {
 }
 
 function Sections() {
-  const { scenarios } = useAppData();
-  const { data: scenariosData } = scenarios;
+  const { loading, errors, scenarios } = useAppData();
+  const { data: scenariosData, loading: scenariosLoading, errors: scenariosErrors } = scenarios;
   const { search } = useLocation();
 
   const [isComparing] = useComparisonModeState();
@@ -127,6 +128,30 @@ function Sections() {
     currentSearchParams.set('jobAreas', selectedRouteIds.map((id) => `${id}::future`).join(','));
     return currentSearchParams.toString() ? `?${currentSearchParams.toString()}` : '';
   })();
+
+  if ((scenariosLoading || loading) && !scenariosData) {
+    return [
+      <div key="placeholder-loading">
+        <p>Loading...</p>
+      </div>,
+    ];
+  }
+
+  if (errors) {
+    return [
+      <div key="placeholder-error">
+        <p>Error: {errors.join(', ')}</p>
+      </div>,
+    ];
+  }
+
+  if (scenariosErrors) {
+    return [
+      <div key="placeholder-error-2">
+        <p>Error: {scenariosErrors.join(', ')}</p>
+      </div>,
+    ];
+  }
 
   return [
     <Section title="Coverage" key={0}>

--- a/frontend/src/views/GeneralAccess.tsx
+++ b/frontend/src/views/GeneralAccess.tsx
@@ -26,7 +26,7 @@ import { useAppData, useMapData } from '../hooks';
 import { listOxford, notEmpty, requireKey, toTidyNominal } from '../utils';
 
 export function GeneralAccess() {
-  const { data } = useAppData();
+  const { data, loading } = useAppData();
   const [mapView, setMapView] = useState<__esri.MapView | null>(null);
   const {
     networkSegments,
@@ -41,6 +41,7 @@ export function GeneralAccess() {
   return (
     <CoreFrame
       outerStyle={{ height: '100%' }}
+      loading={loading}
       header={<AppNavigation />}
       sectionsHeader={<SectionsHeader />}
       sidebar={<Sidebar />}
@@ -101,7 +102,7 @@ function Sections() {
   const { data, loading, errors, travelMethodList } = useAppData();
   const { search } = useLocation();
 
-  if (loading) {
+  if (loading && !data) {
     return [
       <div key="placeholder-loading">
         <p>Loading...</p>

--- a/frontend/src/views/JobAccess.tsx
+++ b/frontend/src/views/JobAccess.tsx
@@ -9,6 +9,8 @@ import { useAppData } from '../hooks';
 import { notEmpty } from '../utils';
 
 export function JobAccess() {
+  const { loading, scenarios } = useAppData();
+
   // if no areas or seasons are selected, use the ones from tab 1
   const [searchParams, setSearchParams] = useSearchParams();
   useEffect(() => {
@@ -36,6 +38,7 @@ export function JobAccess() {
   return (
     <CoreFrame
       outerStyle={{ height: '100%' }}
+      loading={loading || scenarios.loading}
       sectionsStyle={{
         display: 'grid',
         gridTemplateColumns: 'repeat(auto-fit, minmax(clamp(300px, 100%, 600px), 1fr))',
@@ -51,7 +54,23 @@ export function JobAccess() {
 }
 
 function Sections() {
-  const { jobDataByArea, domain, colorScheme } = useJobData();
+  const { jobDataByArea, domain, colorScheme, loading, errors } = useJobData();
+
+  if (loading && !jobDataByArea) {
+    return [
+      <div key="placeholder-loading">
+        <p>Loading...</p>
+      </div>,
+    ];
+  }
+
+  if (errors) {
+    return [
+      <div key="placeholder-error">
+        <p>Error: {errors.join(', ')}</p>
+      </div>,
+    ];
+  }
 
   return [
     ...jobDataByArea.map((areaData, index) => {
@@ -70,7 +89,7 @@ function Sections() {
 }
 
 function useJobData() {
-  const { data, scenarios } = useAppData();
+  const { data, loading, errors, scenarios } = useAppData();
 
   const [searchParams] = useSearchParams();
   const selectedRouteIds = (searchParams.get('jobAreas')?.split(',').filter(notEmpty) || [])
@@ -183,7 +202,13 @@ function useJobData() {
     ...d3.schemeObservable10.slice(6),
   ];
 
-  return { jobDataByArea: combinedJobData, domain, colorScheme };
+  return {
+    jobDataByArea: combinedJobData,
+    domain,
+    colorScheme,
+    loading: loading || scenarios.loading,
+    errors: errors || scenarios.errors,
+  };
 }
 
 interface HeaderProps {}

--- a/frontend/src/views/RoadsVsTransit.tsx
+++ b/frontend/src/views/RoadsVsTransit.tsx
@@ -8,7 +8,7 @@ import { useFutureMapData, useMapData } from '../hooks/useMapData';
 import { notEmpty } from '../utils';
 
 export function RoadsVsTransit() {
-  const { data, scenarios: scenariosData } = useAppData();
+  const { data, loading, scenarios: scenariosData } = useAppData();
   const {
     areaPolygons,
     routes,
@@ -28,6 +28,7 @@ export function RoadsVsTransit() {
   return (
     <CoreFrame
       outerStyle={{ height: '100%' }}
+      loading={loading || scenariosData.loading}
       header={<AppNavigation />}
       map={
         <div style={{ height: '100%' }}>


### PR DESCRIPTION
These changes add a loading overlay to the tab contents when the data needed by the tab is still downloading. The overlay only appears after 500 milliseconds, so it should only be visible for users with slower connections to the data source. The loading indicator does not appear when downloading the network segments vector tiles.

Resolves #108.

Preview on 4G:

https://github.com/user-attachments/assets/bb4aed05-6d21-4e4c-948e-6b24aafec93a






