### PR TITLE
feat(frontend): add quick toggle button for bus stops layers

### DIFF
--- a/frontend/src/components/common/IconButton/ParatransitIcon.tsx
+++ b/frontend/src/components/common/IconButton/ParatransitIcon.tsx
@@ -7,8 +7,8 @@ export function ParatransitIcon() {
       viewBox="0 0 554.02 332.2"
     >
       <rect
-        fill="#000"
-        stroke="#000"
+        fill="currentColor"
+        stroke="currentColor"
         stroke-miterlimit="10"
         x=".5"
         y=".5"
@@ -17,7 +17,7 @@ export function ParatransitIcon() {
       />
       <ellipse
         fill="#fff"
-        stroke="#000"
+        stroke="currentColor"
         stroke-miterlimit="10"
         cx="62.89"
         cy="234.75"
@@ -26,7 +26,7 @@ export function ParatransitIcon() {
       />
       <ellipse
         fill="#fff"
-        stroke="#000"
+        stroke="currentColor"
         stroke-miterlimit="10"
         cx="218.93"
         cy="234.75"
@@ -35,7 +35,7 @@ export function ParatransitIcon() {
       />
       <rect
         fill="#fff"
-        stroke="#000"
+        stroke="currentColor"
         stroke-miterlimit="10"
         x="22.97"
         y="21.39"
@@ -43,27 +43,27 @@ export function ParatransitIcon() {
         height="152.2"
       />
       <path
-        fill="#000"
-        stroke="#000"
+        fill="currentColor"
+        stroke="currentColor"
         stroke-miterlimit="10"
         d="M92.83,295.91c0,19.77-13.4,35.79-29.94,35.79s-29.94-16.02-29.94-35.79h59.88Z"
       />
       <path
-        fill="#000"
-        stroke="#000"
+        fill="currentColor"
+        stroke="currentColor"
         stroke-miterlimit="10"
         d="M248.87,295.91c0,19.77-13.4,35.79-29.94,35.79s-29.94-16.02-29.94-35.79h59.88Z"
       />
       <polygon
-        fill="#000"
-        stroke="#000"
+        fill="currentColor"
+        stroke="currentColor"
         stroke-miterlimit="10"
         points="551.74 308.05 296.5 284.81 293.71 159.25 379.38 210.91 551.74 308.05"
       />
       <g>
         <rect
-          fill="#000"
-          stroke="#000"
+          fill="currentColor"
+          stroke="currentColor"
           stroke-miterlimit="10"
           x="430.95"
           y="94.93"
@@ -71,26 +71,26 @@ export function ParatransitIcon() {
           height="69.01"
         />
         <polygon
-          fill="#000"
-          stroke="#000"
+          fill="currentColor"
+          stroke="currentColor"
           stroke-miterlimit="10"
           points="503.46 146.43 503.46 163.99 449.45 163.99 449.45 145.4 503.46 146.43"
         />
         <polygon
-          fill="#000"
-          stroke="#000"
+          fill="currentColor"
+          stroke="currentColor"
           stroke-miterlimit="10"
           points="541.18 195.21 528.31 205.63 488.74 156.77 503.69 146.63 541.18 195.21"
         />
         <polygon
-          fill="#000"
-          stroke="#000"
+          fill="currentColor"
+          stroke="currentColor"
           stroke-miterlimit="10"
           points="468.6 114.08 483.89 132.67 449.57 132.67 449.57 114.08 468.6 114.08"
         />
         <ellipse
-          fill="#000"
-          stroke="#000"
+          fill="currentColor"
+          stroke="currentColor"
           stroke-miterlimit="10"
           cx="440.26"
           cy="73.4"
@@ -98,14 +98,14 @@ export function ParatransitIcon() {
           ry="14.25"
         />
         <path
-          fill="#000"
-          stroke="#000"
+          fill="currentColor"
+          stroke="currentColor"
           stroke-miterlimit="10"
           d="M495.45,200.58c-1.52.28-5.39,8.93-8.77,12.68-1.66,1.84-1.06,1.65-12.19,9,0,0,.77-.42,0,0-20.34,10.94-43.88,6.51-43.88,6.51-5.91-1.11-16.07-3.15-25.31-10.88-5.9-4.94-9.06-10.24-10.8-13.2-1.96-3.35-6.25-10.86-7.06-21.21-1.03-13.18,4.2-23,7.2-28.63,8.9-16.72,21.86-22.99,22.94-23.4.01,0,2.45-.94,2.45-.94,1.83-2.16,2.75-2.3,3.22-2.16,1.24.38,1.28,3.31,1.3,7.33.02,3.91.03,5.86-.48,7.55-1.15,3.78-3.76,5.52-7.2,8.74,0,0-5.86,5.48-9.95,11.66-6.81,10.28-5.05,21.77-4.92,22.54,1.72,10.23,8.48,16.59,10.25,18.2,13.33,12.18,38.05,14.18,55.47,3.46,16.06-9.89,20.19-27.16,21.27-31.98.23-1.03.12-.91,1.05-1.14"
         />
         <path
-          fill="#000"
-          stroke="#000"
+          fill="currentColor"
+          stroke="currentColor"
           stroke-miterlimit="10"
           d="M424.51,125v12.58c0,1.15-.08.59-1.87,1.89-3.43,1.95-2.08,1.57-4.06,1.57h-43.84v-16.04h49.78Z"
         />

--- a/frontend/src/components/common/IconButton/WalkshedIcon.tsx
+++ b/frontend/src/components/common/IconButton/WalkshedIcon.tsx
@@ -8,14 +8,14 @@ export function WalkshedIcon() {
     >
       <path
         fill="none"
-        stroke="#000"
+        stroke="currentColor"
         stroke-width="10"
         stroke-miterlimit="10"
         d="M5.43,405.23c-18.75.1,583.5,1.14,568.01.93"
       />
       <ellipse
-        fill="#000"
-        stroke="#000"
+        fill="currentColor"
+        stroke="currentColor"
         stroke-width="10"
         stroke-miterlimit="10"
         cx="275.81"
@@ -25,42 +25,42 @@ export function WalkshedIcon() {
       />
       <path
         fill="none"
-        stroke="#000"
+        stroke="currentColor"
         stroke-width="60"
         stroke-miterlimit="10"
         d="M275.81,131.81c0-6.8,0,105.99,0,103.34"
       />
       <path
         fill="none"
-        stroke="#000"
+        stroke="currentColor"
         stroke-width="25"
         stroke-miterlimit="10"
         d="M294.05,123.57c-3.21-3.57,84.39,91.88,83.67,90.87"
       />
       <path
         fill="none"
-        stroke="#000"
+        stroke="currentColor"
         stroke-width="25"
         stroke-miterlimit="10"
         d="M257.61,123.48c1.41-1.06-67.95,51.34-64.3,48.57"
       />
       <path
         fill="none"
-        stroke="#000"
+        stroke="currentColor"
         stroke-width="25"
         stroke-miterlimit="10"
         d="M193.18,175.38c-.84-1.69,29.94,58.88,26.64,52.49"
       />
       <path
         fill="none"
-        stroke="#000"
+        stroke="currentColor"
         stroke-width="35"
         stroke-miterlimit="10"
         d="M288.98,247.41c-4.44-5.9,89.91,119.89,82.63,110.09"
       />
       <path
         fill="none"
-        stroke="#000"
+        stroke="currentColor"
         stroke-width="36"
         stroke-miterlimit="10"
         d="M262.23,244.32c3.99-7.34-68.34,125.67-64.29,118.23"

--- a/frontend/src/components/common/Map/Map.tsx
+++ b/frontend/src/components/common/Map/Map.tsx
@@ -239,6 +239,24 @@ export function Map(props: MapProps) {
     }
   }
 
+  const quickToggleLayers = {
+    stops: layers?.filter((layer) => layer.id.startsWith('stops__')) || [],
+  };
+
+  function quickToggleLayer(layerToShow: 'stops') {
+    // get the current visibility
+    const isVisible = quickToggleLayers[layerToShow]?.every((layer) => layer.visible) ?? false;
+
+    // toggle the clicked layer
+    if (quickToggleLayers[layerToShow]) {
+      quickToggleLayers[layerToShow].forEach((layerInfo) => {
+        if (layerInfo) {
+          layerInfo.layer.visible = !isVisible;
+        }
+      });
+    }
+  }
+
   const [showLayerList, setShowLayerList] = useState(true);
 
   return (
@@ -287,6 +305,27 @@ export function Map(props: MapProps) {
             ) : null}
           </SegmentedControlContainer>
         </arcgis-placement>
+
+        {quickToggleLayers.stops.length ? (
+          <arcgis-placement position="top-left">
+            <IconButton
+              title="Toggle bus stop visibility"
+              onClick={() => quickToggleLayer('stops')}
+              active={quickToggleLayers.stops.every((layer) => layer.visible)}
+            >
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <path
+                  d="M8 16a1 1 0 1 0 0-2 1 1 0 0 0 0 2ZM17 15a1 1 0 1 1-2 0 1 1 0 0 1 2 0ZM10.75 5a.75.75 0 0 0 0 1.5h2.5a.75.75 0 0 0 0-1.5h-2.5Z"
+                  fill="currentColor"
+                />
+                <path
+                  d="M7.75 2A3.75 3.75 0 0 0 4 5.75V9.5H2.75a.75.75 0 1 0 0 1.5H4v8.75c0 .966.783 1.75 1.75 1.75h1.5A1.75 1.75 0 0 0 9 19.75V18.5h6v1.25c0 .966.784 1.75 1.75 1.75h1.5A1.75 1.75 0 0 0 20 19.75V11h1.227a.75.75 0 0 0 0-1.5H20V5.75A3.75 3.75 0 0 0 16.25 2h-8.5ZM18.5 18.5v1.25a.25.25 0 0 1-.25.25h-1.5a.25.25 0 0 1-.25-.25V18.5h2Zm0-1.5h-13v-4h13v4Zm-13 2.75V18.5h2v1.25a.25.25 0 0 1-.25.25h-1.5a.25.25 0 0 1-.25-.25Zm0-14A2.25 2.25 0 0 1 7.75 3.5h8.5a2.25 2.25 0 0 1 2.25 2.25v5.75h-13V5.75Z"
+                  fill="currentColor"
+                />
+              </svg>
+            </IconButton>
+          </arcgis-placement>
+        ) : null}
 
         <arcgis-placement position="bottom-left">
           <div>

--- a/frontend/src/hooks/useMapData.tsx
+++ b/frontend/src/hooks/useMapData.tsx
@@ -215,6 +215,7 @@ export function useMapData(data: AppData, view?: __esri.MapView | null) {
         .map(({ __quarter, __year, stops }) => {
           return {
             title: `Stops (${__year} ${__quarter})`,
+            id: `stops__${__year}_${__quarter}`,
             data: stops,
             renderer: createBusStopRenderer(),
             minScale: 240000, // do not show bus stops at scales larger than 1:240,000
@@ -792,6 +793,7 @@ export function useFutureMapData(data: AppFutureRoutesData, allowedRouteIds?: st
       .map(({ stops, __routeId }) => {
         return {
           title: `Stops (${__routeId})`,
+          id: `stops__future__${__routeId}`,
           data: stops,
           renderer: createBusStopRenderer(new Color('rgba(35, 148, 0, 1)')),
           minScale: 240000, // do not show bus stops at scales larger than 1:240,000


### PR DESCRIPTION
There is now a button in the top-left corner of the map to toggle bus stop layers when they are available