### PR TITLE
feat(frontend): consolidate future route layer labels in the legend

### DIFF
--- a/frontend/src/components/common/Map/Map.tsx
+++ b/frontend/src/components/common/Map/Map.tsx
@@ -257,6 +257,132 @@ export function Map(props: MapProps) {
     }
   }
 
+  function consolidateSymbols(_symbols: typeof symbols) {
+    let futureStopsAlreadyAdded = false;
+    let futureRoutesAlreadyAdded = false;
+    let futureWalkServiceAreaAlreadyAdded = false;
+    let futureBikeServiceAreaAlreadyAdded = false;
+    let futureParatransitServiceAreaAlreadyAdded = false;
+
+    let areaBoundaryLayerAdded = false;
+    let foundMultipleAreaBoundaryLayers = false;
+
+    if (!_symbols || !_symbols.length) {
+      return [];
+    }
+
+    return _symbols
+      .filter((symbol) => {
+        if (!symbol.title) {
+          return true;
+        }
+
+        if (symbol.id.startsWith('stops__future__')) {
+          if (futureStopsAlreadyAdded) {
+            return false;
+          } else {
+            futureStopsAlreadyAdded = true;
+            return true;
+          }
+        }
+
+        if (symbol.id.startsWith('future_route__')) {
+          if (futureRoutesAlreadyAdded) {
+            return false;
+          } else {
+            futureRoutesAlreadyAdded = true;
+            return true;
+          }
+        }
+
+        if (symbol.id.startsWith('area-polygon__')) {
+          if (areaBoundaryLayerAdded) {
+            foundMultipleAreaBoundaryLayers = true;
+            return false;
+          } else {
+            areaBoundaryLayerAdded = true;
+            return true;
+          }
+        }
+
+        if (symbol.id.startsWith('walk-service-area__future__')) {
+          if (futureWalkServiceAreaAlreadyAdded) {
+            return false;
+          } else {
+            futureWalkServiceAreaAlreadyAdded = true;
+            return true;
+          }
+        }
+
+        if (symbol.id.startsWith('bike-service-area__future__')) {
+          if (futureBikeServiceAreaAlreadyAdded) {
+            return false;
+          } else {
+            futureBikeServiceAreaAlreadyAdded = true;
+            return true;
+          }
+        }
+
+        if (symbol.id.startsWith('paratransit-service-area__future__')) {
+          if (futureParatransitServiceAreaAlreadyAdded) {
+            return false;
+          } else {
+            futureParatransitServiceAreaAlreadyAdded = true;
+            return true;
+          }
+        }
+
+        return true;
+      })
+      .map((symbol) => {
+        if (symbol.id.startsWith('stops__future__')) {
+          return {
+            ...symbol,
+            title: 'Future Stops',
+          };
+        }
+
+        if (symbol.id.startsWith('future_route__')) {
+          return {
+            ...symbol,
+            title: 'Future Routes',
+          };
+        }
+
+        if (symbol.id.startsWith('area-polygon__')) {
+          return {
+            ...symbol,
+            title: foundMultipleAreaBoundaryLayers
+              ? 'Selected Areas Boundaries'
+              : 'Selected Area Boundary',
+          };
+        }
+
+        if (symbol.id.startsWith('walk-service-area__future__')) {
+          return {
+            ...symbol,
+            title: 'Future Route Walk Service Area',
+          };
+        }
+
+        if (symbol.id.startsWith('bike-service-area__future__')) {
+          return {
+            ...symbol,
+            title: 'Future Route Bike Service Area',
+          };
+        }
+
+        if (symbol.id.startsWith('paratransit-service-area__future__')) {
+          return {
+            ...symbol,
+            title: 'Future Route Paratransit Service Area',
+          };
+        }
+
+        return symbol;
+      });
+  }
+
   const [showLayerList, setShowLayerList] = useState(true);
 
   return (
@@ -343,7 +469,7 @@ export function Map(props: MapProps) {
                     />
                   </svg>
                 </IconButton>
-                {symbols?.map((layer) => {
+                {consolidateSymbols(symbols).map((layer) => {
                   if (!layer.symbolHTML) {
                     return null;
                   }

--- a/frontend/src/hooks/useMapData.tsx
+++ b/frontend/src/hooks/useMapData.tsx
@@ -816,7 +816,7 @@ export function useFutureMapData(
       .map(({ walk_service_area, __routeId }) => {
         return {
           title: `0.5-Mile Walking Radius from Stops (${__routeId})`,
-          id: `walk-service-area__${__routeId}`,
+          id: `walk-service-area__future__${__routeId}`,
           data: walk_service_area,
           renderer: futureServiceAreaRenderer,
           visible: false,
@@ -831,7 +831,7 @@ export function useFutureMapData(
       .map(({ bike_service_area, __routeId }) => {
         return {
           title: `15-Minute Cycling Radius from Stops (at 15 mph) (${__routeId})`,
-          id: `bike-service-area__${__routeId}`,
+          id: `bike-service-area__future__${__routeId}`,
           data: bike_service_area,
           renderer: futureServiceAreaRenderer,
           visible: false,
@@ -846,7 +846,7 @@ export function useFutureMapData(
       .map(({ paratransit_service_area, __routeId }) => {
         return {
           title: `Paratransit Service Area (${__routeId})`,
-          id: `paratransit-service-area__${__routeId}`,
+          id: `paratransit-service-area__future__${__routeId}`,
           data: paratransit_service_area,
           renderer: futureServiceAreaRenderer,
           visible: false,


### PR DESCRIPTION
Individual layers can still be toggled in the layers manager.

Before:
<img width="715" height="1277" alt="image" src="https://github.com/user-attachments/assets/152592de-cd8d-43c9-91e9-6731e035eeaa" />

After:

<img width="552" height="562" alt="image" src="https://github.com/user-attachments/assets/30e1f0ba-a207-400b-934f-3d718bf08f5a" />
