### PR TITLE
feat(frontend): improve statistics table clairity

### DIFF
--- a/frontend/src/components/common/Statistic/Money.tsx
+++ b/frontend/src/components/common/Statistic/Money.tsx
@@ -61,15 +61,28 @@ export function Money(props: MoneyProps) {
         {Array.isArray(data) ? (
           <div className="table" role="table">
             {data.map(({ label, value }, index) => {
-              return (
-                <React.Fragment key={label + index}>
-                  <span role="cell">{label}</span>
+              const parenthesisContent = label.includes('(')
+                ? label.split('(')[1]?.replace(')', '')
+                : undefined;
+              const cleanLabel = label.includes('(') ? label.split('(')[0]?.trim() || label : label;
 
-                  <span role="cell">
+              return (
+                <tr role="row" key={label + index}>
+                  <td role="cell">
+                    {cleanLabel}
+                    {parenthesisContent ? (
+                      <>
+                        <br />
+                        <span className="caption">{parenthesisContent}</span>
+                      </>
+                    ) : null}
+                  </td>
+
+                  <td role="cell">
                     {'$'}
                     {parseFloat((typeof value === 'string' ? parseFloat(value) : value).toFixed(2))}
-                  </span>
-                </React.Fragment>
+                  </td>
+                </tr>
               );
             })}
           </div>

--- a/frontend/src/components/common/Statistic/Number.tsx
+++ b/frontend/src/components/common/Statistic/Number.tsx
@@ -61,11 +61,24 @@ export function Number(props: NumberProps) {
         {Array.isArray(data) ? (
           <div className="table" role="table">
             {data.map(({ label, value }, index) => {
+              const parenthesisContent = label.includes('(')
+                ? label.split('(')[1]?.replace(')', '')
+                : undefined;
+              const cleanLabel = label.includes('(') ? label.split('(')[0]?.trim() || label : label;
+
               return (
-                <React.Fragment key={label + index}>
-                  <span role="cell">{label}</span>
-                  <span role="cell">{value.toLocaleString()}</span>
-                </React.Fragment>
+                <tr role="row" key={label + index}>
+                  <td role="cell">
+                    {cleanLabel}
+                    {parenthesisContent ? (
+                      <>
+                        <br />
+                        <span className="caption">{parenthesisContent}</span>
+                      </>
+                    ) : null}
+                  </td>
+                  <td role="cell">{value.toLocaleString()}</td>
+                </tr>
               );
             })}
           </div>

--- a/frontend/src/components/common/Statistic/Percent.tsx
+++ b/frontend/src/components/common/Statistic/Percent.tsx
@@ -50,14 +50,27 @@ export function Percent(props: PercentProps) {
         {Array.isArray(data) ? (
           <div className="table" role="table">
             {data.map(({ label, value }, index) => {
+              const parenthesisContent = label.includes('(')
+                ? label.split('(')[1]?.replace(')', '')
+                : undefined;
+              const cleanLabel = label.includes('(') ? label.split('(')[0]?.trim() || label : label;
+
               return (
-                <React.Fragment key={label + index}>
-                  <span role="cell">{label}</span>
-                  <span role="cell">
+                <tr role="row" key={label + index}>
+                  <td role="cell">
+                    {cleanLabel}
+                    {parenthesisContent ? (
+                      <>
+                        <br />
+                        <span className="caption">{parenthesisContent}</span>
+                      </>
+                    ) : null}
+                  </td>
+                  <td role="cell">
                     {value}
                     <span className="percent">%</span>
-                  </span>
-                </React.Fragment>
+                  </td>
+                </tr>
               );
             })}
           </div>

--- a/frontend/src/components/common/Statistic/StatisticContainer.ts
+++ b/frontend/src/components/common/Statistic/StatisticContainer.ts
@@ -20,6 +20,7 @@ export const StatisticContainer = styled.div`
 
   & > .content {
     display: block;
+    width: 100%;
 
     .percent {
       font-size: 90%;
@@ -28,6 +29,8 @@ export const StatisticContainer = styled.div`
 
     .label {
       font-weight: 500;
+      line-height: 1.1;
+      margin: 0.2rem 0 0.18rem 0;
     }
 
     .label .unit {
@@ -46,13 +49,42 @@ export const StatisticContainer = styled.div`
     }
 
     .table {
-      display: grid;
+      display: table;
+      border-collapse: collapse;
       grid-template-columns: auto 1fr;
-      gap: 0 0.5rem;
-      width: 100%;
+      width: calc(100% + 2rem);
+      margin-top: 0.98rem;
+      margin-left: -1rem;
+      margin-bottom: -1rem;
+      overflow-y: hidden;
 
-      span[role='cell'] {
+      tr {
+        border-top: 1px solid lightgray;
+        border-bottom: 1px solid lightgray;
+      }
+
+      [role='cell'] {
         max-width: 120px;
+        line-height: 1.1;
+        padding: 0.5rem 0 0.5rem 1em;
+        letter-spacing: -0.34px;
+        text-indent: -1rem;
+      }
+
+      [role='cell']:first-of-type {
+        padding-right: 0.5rem;
+        padding-left: 2rem;
+      }
+
+      [role='cell']:last-of-type {
+        padding-right: 1rem;
+      }
+
+      .caption {
+        font-size: 0.825rem;
+        color: var(--text-secondary);
+        opacity: 0.8;
+        margin-left: -1rem;
       }
     }
   }


### PR DESCRIPTION
- there are now borders between rows
- if row labels need multiple lines, subsequent lines are now indentend
- seasons, which used to be in parenthesis, are now below the area name with a smaller font and slightly lighter color

| Before | After |
| --- | --- |
| <img width="403" height="696" alt="image" src="https://github.com/user-attachments/assets/e248595b-665a-49fe-aa19-1fbfa41822e9" /> | <img width="402" height="640" alt="image" src="https://github.com/user-attachments/assets/a595e52d-48f2-4939-9ca1-f9705effc0d0" /> |
