### PR TITLE
feat(frontend): show statistic descriptions for boardings, alightings, and trips that could use public transit

### DIFF
--- a/frontend/src/components/common/Statistic/Figure.tsx
+++ b/frontend/src/components/common/Statistic/Figure.tsx
@@ -6,6 +6,8 @@ import { StatisticContainer as _StatisticContainer } from './StatisticContainer'
 export interface FigureProps {
   /** The label of the figure */
   label: string;
+  /** A short description for the statistic to provide additional clairity. */
+  description?: string;
   /** The optional SVG icon to show in front of the label */
   icon?: React.ReactElement<SVGSVGElement>;
   /** The figure to show. */
@@ -21,7 +23,11 @@ export function Figure(props: FigureProps) {
     <StatisticContainer legendBeforeTitle={props.legendBeforeTitle}>
       {props.icon}
       <div className="content">
-        <div className="label">{props.label}</div>
+        <div className="label">
+          {props.label}
+          {props.description ? <div className="caption">{props.description}</div> : null}
+        </div>
+
         {Array.isArray(props.plot) ? (
           props.plot.map((plot, index) => {
             return (

--- a/frontend/src/components/common/Statistic/Money.tsx
+++ b/frontend/src/components/common/Statistic/Money.tsx
@@ -5,6 +5,8 @@ import { StatisticContainer } from './StatisticContainer';
 interface MoneyProps {
   /** The label of the dollar amount statistic(s) */
   label: string;
+  /** A short description for the statistic to provide additional clairity. */
+  description?: string;
   /** The optional SVG icon to show with the statistic(s) */
   icon?: React.ReactElement<SVGSVGElement>;
   /** The data to show. If multiple data objects are provided, a table will be displayed instead of a single value. */
@@ -57,6 +59,7 @@ export function Money(props: MoneyProps) {
         <div className="label">
           {props.label}
           {props.perCapita && Array.isArray(data) ? <span> per person</span> : null}
+          {props.description ? <div className="caption">{props.description}</div> : null}
         </div>
         {Array.isArray(data) ? (
           <div className="table" role="table">

--- a/frontend/src/components/common/Statistic/Number.tsx
+++ b/frontend/src/components/common/Statistic/Number.tsx
@@ -5,6 +5,8 @@ import { StatisticContainer } from './StatisticContainer';
 interface NumberProps {
   /** The label of the numerical statisitc(s) */
   label: string;
+  /** A short description for the statistic to provide additional clairity. */
+  description?: string;
   /** The optional SVG icon to show with the statisitc(s) */
   icon?: React.ReactElement<SVGSVGElement>;
   /** The data to show. If multiple data objects are provided, a table will be displayed instead of a single value. */
@@ -57,6 +59,7 @@ export function Number(props: NumberProps) {
         <div className="label">
           {props.label}
           {props.unit && Array.isArray(data) ? <span className="unit"> ({props.unit})</span> : null}
+          {props.description ? <div className="caption">{props.description}</div> : null}
         </div>
         {Array.isArray(data) ? (
           <div className="table" role="table">

--- a/frontend/src/components/common/Statistic/Percent.tsx
+++ b/frontend/src/components/common/Statistic/Percent.tsx
@@ -6,6 +6,8 @@ import { StatisticContainer } from './StatisticContainer';
 interface PercentProps {
   /** The label of the percentage statisitc(s) */
   label: string;
+  /** A short description for the statistic to provide additional clairity. */
+  description?: string;
   /** The optional SVG icon to show with the statisitc(s) */
   icon?: React.ReactElement<SVGSVGElement>;
   /** The data to show. If multiple data objects are provided, a table will be displayed instead of a single value. */
@@ -46,7 +48,10 @@ export function Percent(props: PercentProps) {
     <StatisticContainer>
       {props.icon}
       <div className="content">
-        <div className="label">{props.label}</div>
+        <div className="label">
+          {props.label}
+          {props.description ? <div className="caption">{props.description}</div> : null}
+        </div>
         {Array.isArray(data) ? (
           <div className="table" role="table">
             {data.map(({ label, value }, index) => {

--- a/frontend/src/components/common/Statistic/StatisticContainer.ts
+++ b/frontend/src/components/common/Statistic/StatisticContainer.ts
@@ -37,6 +37,15 @@ export const StatisticContainer = styled.div`
       font-size: 0.8rem;
     }
 
+    .label .caption {
+      font-size: 0.825rem;
+      color: var(--text-secondary);
+      letter-spacing: -0.34px;
+      font-weight: 400;
+      line-height: 1.1;
+      margin-top: 0.1rem;
+    }
+
     .single-value {
       font-size: 1.5rem;
 

--- a/frontend/src/views/FutureOpportunities.tsx
+++ b/frontend/src/views/FutureOpportunities.tsx
@@ -241,6 +241,7 @@ function Sections() {
       <Statistic.Percent
         wrap
         label="Trips that could use public transit"
+        description="Excludes existing public transit trips"
         data={futures.map(({ stats, __routeId }) => {
           const possibleConversions = stats?.possible_conversions.via_walk || 0;
           const allTrips = Object.values(stats?.methods.__all || {}).reduce(

--- a/frontend/src/views/GeneralAccess.tsx
+++ b/frontend/src/views/GeneralAccess.tsx
@@ -205,6 +205,7 @@ function Sections() {
           <Statistic.Number
             wrap
             label="Boardings"
+            description="Sum of passengers getting on a bus"
             data={data?.map((area) => {
               const boardings = area.ridership?.area.map((stop) => stop.boarding) || [];
               const boardingsTotal = boardings.reduce((sum, value) => sum + (value || 0), 0);
@@ -218,6 +219,7 @@ function Sections() {
           <Statistic.Number
             wrap
             label="Alightings"
+            description="Sum of passengers getting off a bus"
             data={data?.map((area) => {
               const alightings = area.ridership?.area.map((stop) => stop.alighting) || [];
               const alightingsTotal = alightings.reduce((sum, value) => sum + (value || 0), 0);
@@ -295,6 +297,7 @@ function Sections() {
       <Statistic.Percent
         wrap
         label="Any trip that could use public transit"
+        description="Excludes existing public transit trips"
         data={data?.map((area) => {
           const possibleConversions =
             area.statistics?.thursday_trip.possible_conversions.via_walk || 0;


### PR DESCRIPTION
Example:

<img width="403" height="197" alt="image" src="https://github.com/user-attachments/assets/7b240557-6b00-456a-9c64-fd507e3c7935" />
