### PR TITLE
feat(frontened): improve mobile mode usability

### DIFF
--- a/frontend/src/components/common/ErrorBoundary/ErrorBoundary.ts
+++ b/frontend/src/components/common/ErrorBoundary/ErrorBoundary.ts
@@ -3,6 +3,8 @@ import { captureOwnerStack, Component, ErrorInfo, ReactNode } from 'react';
 interface Props {
   children: ReactNode;
   fallback: ReactNode;
+  /** The title that appears in mobile-mode tabs when the error boundary is the top-level component. */
+  title?: string;
 }
 
 interface State {

--- a/frontend/src/components/common/Map/Map.tsx
+++ b/frontend/src/components/common/Map/Map.tsx
@@ -23,11 +23,12 @@ import type { GeoJSONLayerInit } from './types';
 interface MapProps {
   layers: (GeoJSONLayerInit | WebTileLayer | VectorTileLayer)[];
   onMapReady?: (map: __esri.Map, view: __esri.MapView) => void;
+  neverShowExpandedLayersListOnLoad?: boolean;
 }
 
 export function Map(props: MapProps) {
   const mapElem = useRef<HTMLArcgisMapElement>(null);
-  const { height: mapHeight } = useRect(mapElem);
+  const { height: mapHeight, width: mapWidth } = useRect(mapElem);
 
   // track when the map is ready or is replaced
   const [map, setMap] = useState<__esri.Map | null>(null);
@@ -385,7 +386,14 @@ export function Map(props: MapProps) {
       });
   }
 
-  const [showLayerList, setShowLayerList] = useState(true);
+  const [showLayerList, setShowLayerList] = useState<boolean | null>(
+    props.neverShowExpandedLayersListOnLoad ? false : null
+  );
+  useEffect(() => {
+    if (showLayerList === null && mapHeight > 0 && mapWidth > 0 && symbols && symbols.length) {
+      setShowLayerList(mapHeight !== null && mapHeight > 600 && mapWidth > 420);
+    }
+  }, [showLayerList, mapHeight, mapWidth, symbols, setShowLayerList]);
 
   return (
     <div style={{ height: '100%' }}>

--- a/frontend/src/components/common/Section/Section.tsx
+++ b/frontend/src/components/common/Section/Section.tsx
@@ -4,6 +4,8 @@ import type { JSX } from 'react';
 interface SectionProps {
   /** The label for the section, which appears above the children's grid area */
   title: string;
+  /** The label for the section when it is being rendered as a tab in mobile mode. If missing, title will be used instead. */
+  shortTitle?: string;
   /** The heading level to use for the title. Defaults to 2 (h2). */
   level?: number;
   /**

--- a/frontend/src/components/layout/CoreFrame/CoreFrame.tsx
+++ b/frontend/src/components/layout/CoreFrame/CoreFrame.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import { useContext, useEffect, useRef, useState } from 'react';
+import { notEmpty } from '../../../utils';
 import { ProgressRing, Tab } from '../../common';
 import { CoreFrameContext } from './CoreFrameContext';
 import { SidebarWrapper } from './SidebarWrapper';
@@ -61,24 +62,22 @@ export function CoreFrame(props: CoreFrameProps) {
           {isMobile ? (
             <>
               <div style={{ gridArea: 'section-tabs' }}>
-                {[props.map, ...(props.sections || [])]
-                  .filter((x) => !!x)
-                  .map((section, index) => {
-                    const tabLabel =
-                      (section.props as Record<string, unknown>).title?.toString() ||
-                      `Tab ${index + 1}`;
-                    return (
-                      <Tab
-                        key={index}
-                        onClick={() => {
-                          setActiveMobileSection(index);
-                        }}
-                        label={tabLabel}
-                        variant="line"
-                        isActive={activeMobileSection === index}
-                      />
-                    );
-                  })}
+                {[props.map, ...(props.sections || [])].filter(notEmpty).map((section, index) => {
+                  const tabLabel =
+                    (section.props as Record<string, unknown>).title?.toString() ||
+                    `Tab ${index + 1}`;
+                  return (
+                    <Tab
+                      key={index}
+                      onClick={() => {
+                        setActiveMobileSection(index);
+                      }}
+                      label={tabLabel}
+                      variant="line"
+                      isActive={activeMobileSection === index}
+                    />
+                  );
+                })}
               </div>
               <MainAreaWrapper>
                 {props.sectionsHeader}
@@ -86,7 +85,7 @@ export function CoreFrame(props: CoreFrameProps) {
                   disableSectionColumns={props.disableSectionColumns}
                   style={props.sectionsStyle}
                 >
-                  {[props.map, ...(props.sections || [])][activeMobileSection]}
+                  {[props.map, ...(props.sections || [])].filter(notEmpty)[activeMobileSection]}
                 </MainArea>
               </MainAreaWrapper>
             </>

--- a/frontend/src/components/layout/CoreFrame/CoreFrame.tsx
+++ b/frontend/src/components/layout/CoreFrame/CoreFrame.tsx
@@ -64,6 +64,7 @@ export function CoreFrame(props: CoreFrameProps) {
               <div style={{ gridArea: 'section-tabs' }}>
                 {[props.map, ...(props.sections || [])].filter(notEmpty).map((section, index) => {
                   const tabLabel =
+                    (section.props as Record<string, unknown>).shortTitle?.toString() ||
                     (section.props as Record<string, unknown>).title?.toString() ||
                     `Tab ${index + 1}`;
                   return (

--- a/frontend/src/components/layout/PageHeader/PageHeader.tsx
+++ b/frontend/src/components/layout/PageHeader/PageHeader.tsx
@@ -8,8 +8,7 @@ export const PageHeader = styled.div<{ isComparing?: boolean }>`
   border-bottom: 1px solid lightgray;
   @container core (max-width: 899px) {
     padding: 0rem 0.5rem;
-    margin-top: -0.5rem;
-    margin-bottom: -0.5rem;
+    margin-bottom: -1rem;
     border-bottom: none;
   }
 

--- a/frontend/src/views/EssentialServicesAccess.tsx
+++ b/frontend/src/views/EssentialServicesAccess.tsx
@@ -156,7 +156,11 @@ function Sections() {
   }
 
   return [
-    <Section title="Essential Services Access via Public Transit" key={0}>
+    <Section
+      title="Essential Services Access via Public Transit"
+      shortTitle="Via Public Transit"
+      key={0}
+    >
       <Statistic.Percent
         label="Grocery Stores"
         wrap
@@ -241,7 +245,11 @@ function Sections() {
         })}
       />
     </Section>,
-    <Section title="Recorded Average Travel Time to Essential Services via Public Transit" key={1}>
+    <Section
+      title="Recorded Average Travel Time to Essential Services via Public Transit"
+      shortTitle="Travel Time"
+      key={1}
+    >
       <Statistic.Number
         label="Grocery Stores"
         wrap

--- a/frontend/src/views/EssentialServicesAccess.tsx
+++ b/frontend/src/views/EssentialServicesAccess.tsx
@@ -75,6 +75,7 @@ export function EssentialServicesAccess() {
             onMapReady={(_, view) => {
               setMapView(view);
             }}
+            neverShowExpandedLayersListOnLoad
           />
         </div>
       }

--- a/frontend/src/views/EssentialServicesAccess.tsx
+++ b/frontend/src/views/EssentialServicesAccess.tsx
@@ -53,7 +53,7 @@ export function EssentialServicesAccess() {
       sectionsHeader={<SectionsHeader />}
       sidebar={<Sidebar />}
       map={
-        <div style={{ height: '100%' }}>
+        <div style={{ height: '100%' }} title="Map">
           <Map
             layers={[
               ...networkSegments,

--- a/frontend/src/views/FutureOpportunities.tsx
+++ b/frontend/src/views/FutureOpportunities.tsx
@@ -61,7 +61,7 @@ export function FutureOpportunities() {
       sectionsHeader={<SectionsHeader />}
       sidebar={<Sidebar />}
       map={
-        <div style={{ height: '100%' }}>
+        <div style={{ height: '100%' }} title="Map">
           <Map
             layers={[
               walkServiceAreas,

--- a/frontend/src/views/GeneralAccess.tsx
+++ b/frontend/src/views/GeneralAccess.tsx
@@ -48,7 +48,7 @@ export function GeneralAccess() {
       sectionsHeader={<SectionsHeader />}
       sidebar={<Sidebar />}
       map={
-        <ErrorBoundary fallback={<div>Map failed to load</div>}>
+        <ErrorBoundary fallback={<div>Map failed to load</div>} title="Map">
           <div style={{ height: '100%' }}>
             <Map
               layers={[

--- a/frontend/src/views/RoadsVsTransit.tsx
+++ b/frontend/src/views/RoadsVsTransit.tsx
@@ -37,7 +37,7 @@ export function RoadsVsTransit() {
       header={<AppNavigation />}
       sectionsHeader={<SectionsHeader />}
       map={
-        <div style={{ height: '100%' }}>
+        <div style={{ height: '100%' }} title="Map">
           <Map
             layers={[
               walkServiceAreas,
@@ -58,7 +58,7 @@ export function RoadsVsTransit() {
           />
         </div>
       }
-      sections={[<Comparison key={0} />]}
+      sections={[<Comparison key={0} title="Scenarios" />]}
       disableSectionColumns
     />
   );
@@ -96,7 +96,7 @@ function SectionsHeader() {
   return null;
 }
 
-function Comparison() {
+function Comparison(_props: { title: string }) {
   const { scenarios: scenariosData } = useAppData();
   const scenarios = scenariosData.data?.scenarios?.scenarios || [];
   const mileOptions = Array.from(new Set(scenarios.map((s) => s.pavementMiles))).map(


### PR DESCRIPTION
- map tab shows map as label
- tab labels and content now correctly correspond to each other when there is no map
- the legend cannot be taller than the map, so the collapse button is now always visible
- the legend will not appear until the symbols are available, which prevents the current broken-looking box in the corner while it loads
- sections can declare short labels for the mobile-mode tabs, which is important when section titles are long (see tab 4)