### PR TITLE
feat(frontend): hide population stats figures with a sample size less than 30 people

### DIFF
--- a/frontend/src/components/sections/AreaDemographics.tsx
+++ b/frontend/src/components/sections/AreaDemographics.tsx
@@ -113,6 +113,9 @@ export function AreaDemographics() {
                   ...preset.color,
                   legend: index === 0,
                 },
+                // require a sample size of at least 30 to display the figure
+                sampleSizeIsTooSmall:
+                  Object.values(plotData).reduce((acc, val) => acc + val.value, 0) < 30,
               };
             };
           })}
@@ -170,6 +173,9 @@ export function AreaDemographics() {
                   ...preset.color,
                   legend: index === 0,
                 },
+                // require a sample size of at least 30 to display the figure
+                sampleSizeIsTooSmall:
+                  Object.values(plotData).reduce((acc, val) => acc + val.value, 0) < 30,
               };
             };
           })}
@@ -232,6 +238,9 @@ export function AreaDemographics() {
                   ...preset.color,
                   legend: index === 0,
                 },
+                // require a sample size of at least 30 to display the figure
+                sampleSizeIsTooSmall:
+                  Object.values(plotData).reduce((acc, val) => acc + val.value, 0) < 30,
               };
             };
           })}

--- a/frontend/src/components/sections/RiderDemographics.tsx
+++ b/frontend/src/components/sections/RiderDemographics.tsx
@@ -73,6 +73,9 @@ export function RiderDemographics() {
                   ...preset.color,
                   legend: index === 0,
                 },
+                // require a sample size of at least 30 to display the figure
+                sampleSizeIsTooSmall:
+                  Object.values(plotData).reduce((acc, val) => acc + val.value, 0) < 30,
               };
             };
           })}
@@ -131,6 +134,9 @@ export function RiderDemographics() {
                   ...preset.color,
                   legend: index === 0,
                 },
+                // require a sample size of at least 30 to display the figure
+                sampleSizeIsTooSmall:
+                  Object.values(plotData).reduce((acc, val) => acc + val.value, 0) < 30,
               };
             };
           })}
@@ -194,6 +200,9 @@ export function RiderDemographics() {
                   ...preset.color,
                   legend: index === 0,
                 },
+                // require a sample size of at least 30 to display the figure
+                sampleSizeIsTooSmall:
+                  Object.values(plotData).reduce((acc, val) => acc + val.value, 0) < 30,
               };
             };
           })}

--- a/frontend/src/components/sections/WorkAndSchool2.tsx
+++ b/frontend/src/components/sections/WorkAndSchool2.tsx
@@ -158,6 +158,9 @@ export function WorkAndSchool2() {
                   ...preset.color,
                   legend: index === 0,
                 },
+                // require a sample size of at least 30 to display the figure
+                sampleSizeIsTooSmall:
+                  Object.values(plotData).reduce((acc, val) => acc + val.value, 0) < 30,
               };
             };
           })}


### PR DESCRIPTION
<img width="391" height="319" alt="image" src="https://github.com/user-attachments/assets/a7d96eaf-e3f0-4fae-be98-1aa67a3736fd" />
