### PR TITLE
feat(frontend): add tab explainer text from Stephen

### DIFF
--- a/frontend/src/assets/theme.css
+++ b/frontend/src/assets/theme.css
@@ -7,10 +7,12 @@
   --color-green1: #67a24e;
   --color-green2: #83bd45;
   --color-green3: #3d9356;
+  --color-green3--parts: 137, 41%, 41%;
   --color-blue: #222e5d;
   --color-purple: #5e1c6f;
 
   --color-primary: var(--color-green3);
+  --color-primary--parts: var(--color-green3--parts);
   --color-secondary: var(--color-purple);
 
   --color-primary--hover: hsl(145, 39%, 35%);

--- a/frontend/src/components/layout/PageHeader/PageHeader.tsx
+++ b/frontend/src/components/layout/PageHeader/PageHeader.tsx
@@ -80,6 +80,7 @@ export const PageHeader = styled.div<{ isComparing?: boolean }>`
     border: 1px solid lightgray;
     padding: 0.5rem;
     border-radius: var(--surface-radius);
+    text-align: left;
 
     ${_StyledIconButton} {
       position: absolute;

--- a/frontend/src/components/layout/PageHeader/PageHeader.tsx
+++ b/frontend/src/components/layout/PageHeader/PageHeader.tsx
@@ -114,4 +114,34 @@ export const PageHeader = styled.div<{ isComparing?: boolean }>`
       margin-top: 0.5rem;
     }
   }
+
+  .showAside {
+    appearance: none;
+    border: none;
+    background-color: transparent;
+    margin: 0;
+    padding: 0;
+    cursor: pointer;
+    font-family: inherit;
+    font-size: inherit;
+
+    color: var(--color-primary);
+    box-shadow: 0 1px 0 0 var(--color-primary);
+    transition: background-color 0.2s, box-shadow 0.1s, color 0.2s;
+    text-decoration: none;
+
+    &:hover {
+      box-shadow: 0 2px 0 0 var(--color-primary);
+      background-color: hsla(var(--color-primary--parts), 0.1);
+      color: var(--text-primary);
+    }
+
+    &:active {
+      background-color: hsla(var(--color-primary--parts), 0.16);
+    }
+
+    @media print {
+      display: none;
+    }
+  }
 `;

--- a/frontend/src/views/EssentialServicesAccess.tsx
+++ b/frontend/src/views/EssentialServicesAccess.tsx
@@ -132,7 +132,7 @@ function SectionsHeader() {
 
   return (
     <PageHeader isComparing={isComparing}>
-      <h2>Which essential services can you access via public transit?</h2>
+      <h2>Who can transit serve?</h2>
       <p>
         Learn what percentage of the population can reach essential services via public transit and
         how long it takes.
@@ -160,14 +160,11 @@ function SectionsHeader() {
             <DismissIcon size={16} />
           </IconButton>
           <p>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
-            incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
-            exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+            From childcare, to grocery shopping, to doctor’s offices, transit is how thousands of
+            people get where they need to be.
           </p>
           <p>
-            Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
-            nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui
-            officia deserunt mollit anim id est laborum.
+            See which essential services are transit accessible and how long it takes to get there.
           </p>
         </aside>
       ) : null}

--- a/frontend/src/views/EssentialServicesAccess.tsx
+++ b/frontend/src/views/EssentialServicesAccess.tsx
@@ -136,6 +136,14 @@ function SectionsHeader() {
       <p>
         Learn what percentage of the population can reach essential services via public transit and
         how long it takes.
+        {showAside ? null : (
+          <>
+            {' '}
+            <button className="showAside" onClick={() => setShowAside(true)}>
+              More info
+            </button>
+          </>
+        )}
       </p>
       {isFullDesktop || isMobile ? null : (
         <div className="button-row">
@@ -153,10 +161,7 @@ function SectionsHeader() {
       {showAside ? (
         <aside>
           <h1>About this tab</h1>
-          <IconButton
-            onClick={() => setShowAside(false)}
-            title="Permanently dismiss this message on this device"
-          >
+          <IconButton onClick={() => setShowAside(false)}>
             <DismissIcon size={16} />
           </IconButton>
           <p>

--- a/frontend/src/views/FutureOpportunities.tsx
+++ b/frontend/src/views/FutureOpportunities.tsx
@@ -107,7 +107,17 @@ function SectionsHeader() {
   return (
     <PageHeader isComparing={isComparing}>
       <h2>Where can transit expand?</h2>
-      <p>Visualize selected future transit routes from Greenlink's transit development plan.</p>
+      <p>
+        Visualize selected future transit routes from Greenlink's transit development plan.
+        {showAside ? null : (
+          <>
+            {' '}
+            <button className="showAside" onClick={() => setShowAside(true)}>
+              More info
+            </button>
+          </>
+        )}
+      </p>
       {isFullDesktop || isMobile ? null : (
         <div className="button-row">
           {isComparing ? (
@@ -121,10 +131,7 @@ function SectionsHeader() {
       {showAside ? (
         <aside>
           <h1>Welcome to the future!</h1>
-          <IconButton
-            onClick={() => setShowAside(false)}
-            title="Permanently dismiss this message on this device"
-          >
+          <IconButton onClick={() => setShowAside(false)}>
             <DismissIcon size={16} />
           </IconButton>
           <p>

--- a/frontend/src/views/FutureOpportunities.tsx
+++ b/frontend/src/views/FutureOpportunities.tsx
@@ -106,7 +106,7 @@ function SectionsHeader() {
 
   return (
     <PageHeader isComparing={isComparing}>
-      <h2>Future Transit Routes & Stops</h2>
+      <h2>Where can transit expand?</h2>
       <p>Visualize selected future transit routes from Greenlink's transit development plan.</p>
       {isFullDesktop || isMobile ? null : (
         <div className="button-row">
@@ -120,7 +120,7 @@ function SectionsHeader() {
       )}
       {showAside ? (
         <aside>
-          <h1>About this tab</h1>
+          <h1>Welcome to the future!</h1>
           <IconButton
             onClick={() => setShowAside(false)}
             title="Permanently dismiss this message on this device"
@@ -128,14 +128,12 @@ function SectionsHeader() {
             <DismissIcon size={16} />
           </IconButton>
           <p>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
-            incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
-            exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+            On this page, you can see how proposed transit routes can bring mobility to more people
+            in Greenville.
           </p>
           <p>
-            Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
-            nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui
-            officia deserunt mollit anim id est laborum.
+            Click the dropdown menu to select a new route, and check the stats to see how the routes
+            stack up.
           </p>
         </aside>
       ) : null}

--- a/frontend/src/views/GeneralAccess.tsx
+++ b/frontend/src/views/GeneralAccess.tsx
@@ -112,6 +112,14 @@ function SectionsHeader() {
       <h2>Where does transit go?</h2>
       <p>
         Viewing: {listOxford(uniqueAreaNames)} for {listOxford(seasons)}
+        {showAside ? null : (
+          <>
+            {' '}
+            <button className="showAside" onClick={() => setShowAside(true)}>
+              More info
+            </button>
+          </>
+        )}
       </p>
       {isFullDesktop || isMobile ? null : (
         <div className="button-row">
@@ -129,10 +137,7 @@ function SectionsHeader() {
       {showAside ? (
         <aside>
           <h1>Welcome to the Greenville Connects transit data dashboard!</h1>
-          <IconButton
-            onClick={() => setShowAside(false)}
-            title="Permanently dismiss this message on this device"
-          >
+          <IconButton onClick={() => setShowAside(false)}>
             <DismissIcon size={16} />
           </IconButton>
           <p>

--- a/frontend/src/views/GeneralAccess.tsx
+++ b/frontend/src/views/GeneralAccess.tsx
@@ -90,9 +90,29 @@ function SectionsHeader() {
 
   const uniqueAreaNames = Array.from(new Set((data || []).map((area) => area.__area))).sort();
 
+  const seasons = Array.from(
+    new Set(
+      (data || []).map((area) => {
+        let seasonString = '';
+        if (area.__quarter === 'Q2') {
+          seasonString = 'April-June';
+        } else if (area.__quarter === 'Q4') {
+          seasonString = 'October-December';
+        }
+        if (area.__year) {
+          seasonString += ` ${area.__year}`;
+        }
+        return seasonString;
+      })
+    )
+  ).sort();
+
   return (
     <PageHeader isComparing={isComparing}>
-      <h2>{listOxford(uniqueAreaNames)}</h2>
+      <h2>Where does transit go?</h2>
+      <p>
+        Viewing: {listOxford(uniqueAreaNames)} for {listOxford(seasons)}
+      </p>
       {isFullDesktop || isMobile ? null : (
         <div className="button-row">
           {isComparing ? (
@@ -108,7 +128,7 @@ function SectionsHeader() {
       )}
       {showAside ? (
         <aside>
-          <h1>About this tab</h1>
+          <h1>Welcome to the Greenville Connects transit data dashboard!</h1>
           <IconButton
             onClick={() => setShowAside(false)}
             title="Permanently dismiss this message on this device"
@@ -116,14 +136,20 @@ function SectionsHeader() {
             <DismissIcon size={16} />
           </IconButton>
           <p>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
-            incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
-            exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+            This is the General Access page. Here, you can see where Greenlink’s routes go, how many
+            riders they service, and how they match with other modes of transportation.
           </p>
           <p>
-            Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
-            nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui
-            officia deserunt mollit anim id est laborum.
+            In the options menu, you can select which area you’d like to get data about, and when
+            that data is from.
+          </p>
+          <p>
+            You can also select which mode of transportation you’d like to see. The weight of the
+            blue lines indicates how often those routes are taken using that form of transportation.{' '}
+          </p>
+          <p>
+            You can enter comparison mode to see how two areas of Greenville compare in their
+            mobility and transit access.
           </p>
         </aside>
       ) : null}

--- a/frontend/src/views/JobAccess.tsx
+++ b/frontend/src/views/JobAccess.tsx
@@ -260,6 +260,14 @@ function Header(props: HeaderProps) {
       <p>
         These tree maps visualize the daily average number of people who use any transport mode to
         reach their job in the selected area(s), grouped by job sector.
+        {showAside ? null : (
+          <>
+            {' '}
+            <button className="showAside" onClick={() => setShowAside(true)}>
+              More info
+            </button>
+          </>
+        )}
       </p>
       <div className="swatches">
         {domain.map((name, index) => {
@@ -278,10 +286,7 @@ function Header(props: HeaderProps) {
       {showAside ? (
         <aside>
           <h1>About this tab</h1>
-          <IconButton
-            onClick={() => setShowAside(false)}
-            title="Permanently dismiss this message on this device"
-          >
+          <IconButton onClick={() => setShowAside(false)}>
             <DismissIcon size={16} />
           </IconButton>
           <p>

--- a/frontend/src/views/JobAccess.tsx
+++ b/frontend/src/views/JobAccess.tsx
@@ -256,7 +256,7 @@ function Header(props: HeaderProps) {
 
   return (
     <HeaderComponent {...props}>
-      <h2>What Jobs Are Here?</h2>
+      <h2>How can transit help the economy?</h2>
       <p>
         These tree maps visualize the daily average number of people who use any transport mode to
         reach their job in the selected area(s), grouped by job sector.
@@ -285,14 +285,12 @@ function Header(props: HeaderProps) {
             <DismissIcon size={16} />
           </IconButton>
           <p>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
-            incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
-            exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+            Employment is among the most crucial benefits of transit. More buses, more places, more
+            often means more access to jobs and economic mobility.
           </p>
           <p>
-            Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
-            nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui
-            officia deserunt mollit anim id est laborum.
+            See the industries that create the most jobs in each area. You’ll see we aren’t lacking
+            for jobs, but we are lacking for reliable transportation to those jobs.
           </p>
         </aside>
       ) : null}

--- a/frontend/src/views/RoadsVsTransit.tsx
+++ b/frontend/src/views/RoadsVsTransit.tsx
@@ -8,21 +8,13 @@ import {
   IconButton,
   manualSectionIds,
   OptionTrack,
-  PageHeader,
   renderManualSection,
   renderSections,
   SelectOne,
   Map as WebMap,
 } from '../components';
-import { DismissIcon } from '../components/common/IconButton/DismssIcon';
 import { AppNavigation } from '../components/navigation';
-import {
-  useAppData,
-  useHighlightHandles,
-  useLocalStorage,
-  useRect,
-  useSectionsVisibility,
-} from '../hooks';
+import { useAppData, useHighlightHandles, useRect, useSectionsVisibility } from '../hooks';
 import { useFutureMapData, useMapData } from '../hooks/useMapData';
 import { mapUtils, notEmpty } from '../utils';
 
@@ -59,7 +51,6 @@ export function RoadsVsTransit() {
       outerStyle={{ height: '100%' }}
       loading={loading || scenariosData.loading}
       header={<AppNavigation />}
-      sectionsHeader={<SectionsHeader />}
       map={
         render(
           <div style={{ height: '100%' }} title="Map">
@@ -124,38 +115,6 @@ export function RoadsVsTransit() {
       disableSectionColumns
     />
   );
-}
-
-function SectionsHeader() {
-  const [showAside, setShowAside] = useLocalStorage('aside--tab-5', true);
-
-  if (showAside) {
-    return (
-      <PageHeader>
-        <aside>
-          <h1>About this tab</h1>
-          <IconButton
-            onClick={() => setShowAside(false)}
-            title="Permanently dismiss this message on this device"
-          >
-            <DismissIcon size={16} />
-          </IconButton>
-          <p>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
-            incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
-            exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
-          </p>
-          <p>
-            Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
-            nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui
-            officia deserunt mollit anim id est laborum.
-          </p>
-        </aside>
-      </PageHeader>
-    );
-  }
-
-  return null;
 }
 
 function Comparison(props: { title: string; mapView: __esri.MapView | null }) {
@@ -281,8 +240,11 @@ function Comparison(props: { title: string; mapView: __esri.MapView | null }) {
             transition: 'var(--wui-control-faster-duration) opacity',
           }}
         >
-          <p>1 mile of road pavement costs around $1 Million -</p>
-          <p>What happens when this amount is spent on public transit instead?</p>
+          <p>One mile of road costs around $1 million!</p>
+          <p>
+            What if we invested that money in transit infrastructure instead? Click compare, select
+            a distance of paved road, and see how we can fund new transit projects.
+          </p>
         </div>
 
         <img src="./img/bus.webp" alt="" className="bus-container" />


### PR DESCRIPTION
Expanded
<img width="815" height="640" alt="image" src="https://github.com/user-attachments/assets/e7164f64-0e92-4cc3-9f5f-5d27d477a968" />

Collapsed
<img width="803" height="165" alt="image" src="https://github.com/user-attachments/assets/fc6c8628-cdb0-4dd0-a987-d01715bd04a1" />

