### PR TITLE
feat(frontend): zoom to highlighted features on tab 5 (roads or transit)

### DIFF
--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -11,5 +11,6 @@ export { quadraticBezierToPolygon } from './quadraticBezierToPolygon';
 export { replaceLast } from './replaceLast';
 export { requireKey } from './requireKey';
 export { shouldRenderStatistic } from './shouldRenderStatistic';
+export { toSqlList } from './toSqlList';
 export { toTidyNominal } from './toTidyNominal';
 export { withOpacity } from './withOpacity';

--- a/frontend/src/utils/map/highlightFeatures.ts
+++ b/frontend/src/utils/map/highlightFeatures.ts
@@ -1,5 +1,7 @@
+import Query from '@arcgis/core/rest/support/Query.js';
 import { notEmpty } from '../notEmpty';
 import { requireKey } from '../requireKey';
+import { toSqlList } from '../toSqlList';
 import { getLayerById } from './getLayerById';
 
 type EsriHighlightTarget = Parameters<__esri.GeoJSONLayerView['highlight']>[0];
@@ -35,15 +37,18 @@ export async function highlightFeatures(
       return null;
     }
 
+    // construct a comparable WHERE clause (for the ability to query the highlighted features later)
+    const targetQuery = constructComparableQuery(layerView, target);
+
     // if no target is specified, highlight all features in the layer
     if (target === undefined) {
       const handle = await highlightLayer(layerView, abortableOptions);
-      return { handle, layerView };
+      return { handle, layerView, targetQuery };
     }
 
     // otherwise, highlight the specified features
     const handle = highlightLayerFeatures(layerView, target, abortableOptions);
-    return { handle, layerView };
+    return { handle, layerView, targetQuery };
   });
 
   // resolve the promises and remove the nulls
@@ -51,6 +56,57 @@ export async function highlightFeatures(
     .filter(notEmpty)
     .filter(requireKey('handle'));
   return handles;
+}
+
+/**
+ * Converts a highlight target into a Query that can be used to query the same features.
+ *
+ * If the target cannot be converted, this function will return `undefined`.
+ */
+function constructComparableQuery(layerView: __esri.LayerView, target?: EsriHighlightTarget) {
+  if (
+    !('objectIdField' in layerView.layer) ||
+    !layerView.layer.objectIdField ||
+    typeof layerView.layer.objectIdField !== 'string'
+  ) {
+    return undefined;
+  }
+
+  if (!target) {
+    const allFeaturesQuery = new Query({ where: '1=1' });
+    return allFeaturesQuery;
+  }
+
+  // handle single id target
+  if (typeof target === 'number' || typeof target === 'string') {
+    return new Query({ where: `${layerView.layer.objectIdField} = ${target}` });
+  }
+
+  // handle array of ids target
+  if (
+    Array.isArray(target) &&
+    target.every((t) => typeof t === 'number' || typeof t === 'string')
+  ) {
+    return new Query({ where: `${layerView.layer.objectIdField} IN (${toSqlList(target)})` });
+  }
+
+  // handle featureset target
+  if (Array.isArray(target)) {
+    const targetObjectIds = target.map((feature) => feature.getObjectId()).filter(notEmpty);
+    if (targetObjectIds.length === 0) {
+      return undefined;
+    }
+    return new Query({
+      where: `${layerView.layer.objectIdField} IN (${toSqlList(targetObjectIds)})`,
+    });
+  }
+
+  // handle single feature target
+  const targetObjectId = target.getObjectId?.();
+  if (!targetObjectId) {
+    return undefined;
+  }
+  return new Query({ where: `${layerView.layer.objectIdField} = ${targetObjectId}` });
 }
 
 /**

--- a/frontend/src/utils/requireKey.ts
+++ b/frontend/src/utils/requireKey.ts
@@ -3,5 +3,6 @@ export function requireKey<T, K extends keyof T>(
 ): (data: T) => data is T & {
   [P in K]: NonNullable<T[P]>;
 } {
-  return (data): data is T & { [P in K]: NonNullable<T[P]> } => data[key] !== null;
+  return (data): data is T & { [P in K]: NonNullable<T[P]> } =>
+    data && data[key] !== null && data[key] !== undefined;
 }

--- a/frontend/src/utils/toSqlList.ts
+++ b/frontend/src/utils/toSqlList.ts
@@ -1,0 +1,41 @@
+/**
+ * Converts an array of primitive values (strings or numbers) into a
+ * SQL-formatted string list.
+ *
+ * - String items will be escaped for single quotes and wrapped in single quotes.
+ * - Number items will be converted directly to their string representation.
+ *
+ * The resulting values are joined by a comma and space.
+ *
+ * @param items The array of strings or numbers to convert.
+ * @returns A SQL-formatted string list suitable for use with SQL IN clauses.
+ *
+ * @example
+ * ```typescript
+ * const fruits = ['apple', 'banana', 'orange'];
+ * const sqlString = toSqlList(fruits);
+ * // Expected output: "'apple', 'banana', 'orange'"
+ *
+ * const itemsWithQuotes = ["john's", "mary's book"];
+ * const sqlStringWithQuotes = toSqlList(itemsWithQuotes);
+ * // Expected output: "'john''s', 'mary''s book'"
+ *
+ * const productIds = [101, 205, 310];
+ * const sqlIds = toSqlList(productIds);
+ * // Expected output: "101, 205, 310"
+ *
+ * const mixedItems = ['test', 42, "another's"];
+ * const sqlMixed = toSqlList(mixedItems);
+ * // Expected output: "'test', 42, 'another''s'"
+ * ```
+ */
+export function toSqlList(items: Array<string | number>): string {
+  return items
+    .map((item) => {
+      if (typeof item === 'string') {
+        return `'${item.replace(/'/g, "''")}'`;
+      }
+      return item; // numbers don't need quotes or escaping
+    })
+    .join(', ');
+}

--- a/frontend/src/views/RoadsVsTransit.tsx
+++ b/frontend/src/views/RoadsVsTransit.tsx
@@ -387,51 +387,71 @@ function TrackButtonExpandedContent(props: TrackButtonExpandedContentProps) {
   // build a mapping of line_id to layer id for the future route layers
   // so that we can easily find the right layer to highlight for a given line_id
   useEffect(() => {
-    props.mapView?.when(async () => {
-      const geoJsonLayers = Array.from(props.mapView?.map?.allLayers || []).filter(
-        (layer): layer is __esri.GeoJSONLayer => layer.type === 'geojson'
-      );
-      const futureRouteLayers = geoJsonLayers.filter((layer) =>
-        layer.id.startsWith('future_route__')
-      );
+    if (!props.mapView) {
+      setLineIdToLayerIdMap(new Map());
+      return;
+    }
 
-      if (!futureRouteLayers || futureRouteLayers.length === 0) {
-        setLineIdToLayerIdMap(new Map());
-        return;
-      }
+    props.mapView
+      .when(() => {
+        // <--- This 'when' callback does NOT need to be async itself for this pattern
+        const processLayers = async () => {
+          // <--- DEFINE an async function here
+          const geoJsonLayers = Array.from(props.mapView?.map?.allLayers || []).filter(
+            (layer): layer is __esri.GeoJSONLayer => layer.type === 'geojson'
+          );
+          const futureRouteLayers = geoJsonLayers.filter((layer) =>
+            layer.id.startsWith('future_route__')
+          );
 
-      // prepare a mapping of line_id to layer id
-      const newLineIdToLayerIdMap = new Map<string, string>();
+          if (!futureRouteLayers || futureRouteLayers.length === 0) {
+            setLineIdToLayerIdMap(new Map());
+            return;
+          }
 
-      for await (const layer of futureRouteLayers) {
-        await layer
-          .queryFeatures()
-          .then((featureSet) => {
-            const lineIds = featureSet.features.map(
-              (feature) => feature.attributes.line_id as string
-            );
+          // prepare a mapping of line_id to layer id
+          const newLineIdToLayerIdMap = new Map<string, string>();
 
-            const uniqueLineIds = Array.from(new Set(lineIds));
-            if (uniqueLineIds.length > 1) {
-              console.warn(`Layer ${layer.id} has multiple line_ids:`, uniqueLineIds);
-            }
+          // Now, the 'for await...of' is inside an async function!
+          // This is the correct place for it.
+          for await (const layer of futureRouteLayers) {
+            // <--- This is now valid!
+            await layer // <--- This await is also valid here.
+              .queryFeatures()
+              .then((featureSet) => {
+                const lineIds = featureSet.features.map(
+                  (feature) => feature.attributes.line_id as string
+                );
 
-            const firstLineId = uniqueLineIds[0];
-            if (!firstLineId) {
-              console.warn(`Layer ${layer.id} has no line_id.`);
-              return;
-            }
+                const uniqueLineIds = Array.from(new Set(lineIds));
+                if (uniqueLineIds.length > 1) {
+                  console.warn(`Layer ${layer.id} has multiple line_ids:`, uniqueLineIds);
+                }
 
-            newLineIdToLayerIdMap.set(firstLineId, layer.id);
-          })
-          .catch((error) => {
-            console.error(`Error querying features for layer ${layer.id}:`, error);
-          });
-      }
+                const firstLineId = uniqueLineIds[0];
+                if (!firstLineId) {
+                  console.warn(`Layer ${layer.id} has no line_id.`);
+                  return;
+                }
 
-      // save the mapping to state
-      setLineIdToLayerIdMap(newLineIdToLayerIdMap);
-    });
+                newLineIdToLayerIdMap.set(firstLineId, layer.id);
+              })
+              .catch((error) => {
+                console.error(`Error querying features for layer ${layer.id}:`, error);
+              });
+          }
+
+          // save the mapping to state
+          setLineIdToLayerIdMap(newLineIdToLayerIdMap);
+        };
+
+        processLayers(); // <--- Call the async function immediately after defining it
+      })
+      .catch((error) => {
+        // Good practice to catch errors from .when()
+        console.error('Error waiting for MapView readiness:', error);
+        setLineIdToLayerIdMap(new Map()); // Ensure state is reset even on map load error
+      });
   }, [props.mapView]);
 
   // =========================================================================
@@ -472,9 +492,27 @@ function TrackButtonExpandedContent(props: TrackButtonExpandedContentProps) {
             props.mapView,
             targetLayerIds.map((layerId) => ({ layerId, options: { signal: controller.signal } }))
           )
-          .then((layersAndHandles) => {
+          .then(async (layersAndHandles) => {
+            // <--- This async callback is the key!
             handles.add(layersAndHandles.map(({ handle }) => handle));
+
+            // --- START: Zooming Logic for 'addition' type ---
+            // MOVED: This entire block is now correctly INSIDE the async .then() callback
+            if (targetLayerIds.length > 0) {
+              try {
+                await mapUtils.zoomToLayers(props.mapView!, targetLayerIds); // <--- Non-null assertion added
+              } catch (error) {
+                console.error('Error zooming to features of type "addition":', error);
+              }
+            } else {
+              console.warn(
+                'No layers identified for zooming to highlighted routes (addition type).'
+              );
+            }
+            // --- END: Zooming Logic ---
           });
+        // The .then() chain ends here, and the rest of the useEffect continues synchronously
+        // There should be no other awaits directly here.
       } else if (feature.type === 'frequency') {
         mapUtils
           .highlightFeatures(props.mapView, [

--- a/frontend/src/views/RoadsVsTransit.tsx
+++ b/frontend/src/views/RoadsVsTransit.tsx
@@ -457,7 +457,7 @@ function TrackButtonExpandedContent(props: TrackButtonExpandedContentProps) {
       return;
     }
 
-    // keep trakc of whethere we need to reset the map presentation after removing highlights
+    // keep track of whether we need to reset the map presentation after removing highlights
     let shouldResetZoom = false;
     let busStopLayersToReHideIds: string[] = [];
 

--- a/frontend/src/views/RoadsVsTransit.tsx
+++ b/frontend/src/views/RoadsVsTransit.tsx
@@ -556,7 +556,7 @@ function TrackButtonExpandedContent(props: TrackButtonExpandedContentProps) {
       controller.abort(); // abort any in-progress highlighting
       handles.removeAll(); // remove all active highlights
 
-      //set zoom back to the default extent (the future route layers)
+      // set zoom back to the default extent (the future route layers)
       if (shouldResetZoom) {
         const futureLayerIDs = lineIdToLayerIdMap.values();
         mapUtils.zoomToLayers(props.mapView, Array.from(futureLayerIDs));


### PR DESCRIPTION
The map will now zoom to highlighted routes, future routes, and stops. Additionally, if the stops layer is currently hidden, it will be temporarily unhidden when the selected scenario and scenario feature is related to bus stops.

https://github.com/user-attachments/assets/3e7f18e0-9cce-4c62-b97f-29dd7f82acd8

Additionally, the following changes were added as part of this work:

- `mapUtils.zoomToLayers` now handles the case where an extent may be `null` if the provided `query` results in no features.
- `mapUtils.zoomToLayers` now returns the result of the geometry union (`__esri.GeometryUnion`). If there were no valid extents for the union or something else went wrong, it may return `null` or `undefined`.
- `mapUtils.zoomToLayers` now accepts a null map view. In that case, it returns `undefined`
- `toSqlList` is a new utility function that converts an input array of strings and/or numbers into a SQL-formatted string list that may be used for SQL IN clauses.
- `mapUtils.highlightFeatures` now attempts to generate an Esri Query that is comparable to the specified highlight target. If there is now target, the query will use a where clause that matches all features (`1=1`). The layer must have a value for `objectIdField` for the query to be generated.

Thank you to @mwiniski for getting this started!