### PR TITLE
feat: support new tab5_scenarios structure

### DIFF
--- a/frontend/src/data.d.ts
+++ b/frontend/src/data.d.ts
@@ -585,18 +585,20 @@ interface Scenario {
   pavementMiles: number;
   estimatedCostUSD: number;
   scenarioName: string;
-  features: (
-    | ScenarioStopInfrastructureFeature
-    | ScenarioStopAccessibilityFeature
-    | ScenarioRouteFrequencyFeature
-    | ScenarioRouteAdditionFeature
-    | ScenarioBusPurchaseFeature
-    | ScenarioOnDemandPurchaseFeature
-  )[];
+  featureIds: ScenarioAnyFeature['id'][];
 }
+
+type ScenarioAnyFeature =
+  | ScenarioStopInfrastructureFeature
+  | ScenarioStopAccessibilityFeature
+  | ScenarioRouteFrequencyFeature
+  | ScenarioRouteAdditionFeature
+  | ScenarioBusPurchaseFeature
+  | ScenarioOnDemandPurchaseFeature;
 
 interface ScenarioFeature {
   name: string;
+  id: string;
   description?: string;
   additionalNote?: string;
 }

--- a/frontend/src/hooks/useAppData.ts
+++ b/frontend/src/hooks/useAppData.ts
@@ -893,10 +893,27 @@ function constructScenarioDataPromises(futureRoutesList: string[]) {
 
   return {
     scenarios: (abortSignal?: AbortSignal) =>
-      fetchData<{ scenarios: Scenario[] }>(
+      fetchData<{ scenarios: Scenario[]; features: ScenarioAnyFeature[] }>(
         __GCMD_DATA_ORIGIN__ + __GCMD_DATA_PATH__ + `/tab5_scenarios.json.deflate`,
         abortSignal
-      ).catch(handleError('tab5_scenarios')),
+      )
+        .catch(handleError('tab5_scenarios'))
+        .then((data) => {
+          if (!data) {
+            return null;
+          }
+
+          return {
+            scenarios: data.scenarios.map(({ featureIds, ...rest }) => {
+              return {
+                ...rest,
+                features: featureIds
+                  .map((featureId) => data.features.find((feature) => feature.id === featureId))
+                  .filter(notEmpty),
+              };
+            }),
+          };
+        }),
     futureRoutes: futureRoutesPromises,
   };
 }

--- a/frontend/src/views/RoadsVsTransit.tsx
+++ b/frontend/src/views/RoadsVsTransit.tsx
@@ -359,7 +359,9 @@ function ClickableBackground(props: ClickableBackgroundProps) {
 
 interface TrackButtonExpandedContentProps {
   optionLabel: string;
-  scenarios: Scenario[];
+  scenarios: NonNullable<
+    NonNullable<ReturnType<typeof useAppData>['scenarios']['data']>['scenarios']
+  >['scenarios'];
   transitioning: boolean;
   mapView: __esri.MapView | null;
 }


### PR DESCRIPTION
Features are now stored separately from scenarios. This allows duplicate features to be removed - we now just reference the same feature multiple times.

Thank you for prepping the file, @mwiniski