### PR TITLE
feat(frontend): make tab 5 use dollar amounts, and make the bubble pages more clear

### DIFF
--- a/frontend/src/views/RoadsVsTransit.tsx
+++ b/frontend/src/views/RoadsVsTransit.tsx
@@ -535,9 +535,12 @@ async function showFeaturesOnMap(
 function Comparison(props: { title: string; mapView: __esri.MapView | null }) {
   const { scenarios: scenariosData } = useAppData();
   const scenarios = scenariosData.data?.scenarios?.scenarios || [];
-  const mileOptions = Array.from(new Set(scenarios.map((s) => s.pavementMiles))).map(
-    (m) => `${m} mile${m !== 1 ? 's' : ''}`
-  );
+  const options = Array.from(new Set(scenarios.map((s) => s.pavementMiles))).map((miles) => {
+    return {
+      value: `${miles} mile${miles !== 1 ? 's' : ''}`,
+      label: miles < 1 ? `$${(miles * 1000000).toLocaleString()}` : `$${miles.toFixed(1)} million`,
+    };
+  });
 
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
   const [delayedSelectedIndex, setDelayedSelectedIndex] = useState(selectedIndex);
@@ -570,10 +573,10 @@ function Comparison(props: { title: string; mapView: __esri.MapView | null }) {
   hideSmallButtons;
 
   const trackButtonProps = (index: number) => {
-    const optionLabel = mileOptions[index] || `Option ${index + 1}`;
+    const optionLabel = options[index]?.label || `Option ${index + 1}`;
 
     const buttonScenarios = scenarios.filter(
-      (s) => s.pavementMiles === parseFloat(mileOptions[index]?.split(' ')[0] ?? '-1')
+      (s) => s.pavementMiles === parseFloat(options[index]?.value?.split(' ')[0] ?? '-1')
     );
 
     const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
@@ -608,6 +611,7 @@ function Comparison(props: { title: string; mapView: __esri.MapView | null }) {
               position: 'absolute',
               opacity: selectedIndex !== index ? 1 : 0,
               transition: 'var(--wui-control-faster-duration) opacity',
+              letterSpacing: '-0.44px',
             }}
           >
             {optionLabel}
@@ -625,7 +629,7 @@ function Comparison(props: { title: string; mapView: __esri.MapView | null }) {
             }}
           >
             <TrackButtonExpandedContent
-              optionLabel={optionLabel}
+              optionLabel={optionLabel.replace('.0 million', ' million')}
               scenarios={buttonScenarios}
               transitioning={transitioning}
               mapView={props.mapView}
@@ -657,8 +661,8 @@ function Comparison(props: { title: string; mapView: __esri.MapView | null }) {
         >
           <p>One mile of road costs around $1 million!</p>
           <p>
-            What if we invested that money in transit infrastructure instead? Click compare, select
-            a distance of paved road, and see how we can fund new transit projects.
+            What if we invested that money in transit infrastructure instead? Click <i>Explore</i>,
+            select an approximate dollar amount, and see how we can fund new transit projects.
           </p>
         </div>
 
@@ -716,13 +720,13 @@ function Comparison(props: { title: string; mapView: __esri.MapView | null }) {
 
         <SelectOne
           className="selected-scenario"
-          options={mileOptions}
+          options={options}
           onChange={(value) => {
-            const index = mileOptions.indexOf(value);
+            const index = options.findIndex((o) => o.value === value);
             switchSelectedIndex(index);
           }}
-          value={selectedIndex !== null ? mileOptions[selectedIndex] || '' : ''}
-          placeholder="Compare"
+          value={selectedIndex !== null ? options[selectedIndex]?.value || '' : ''}
+          placeholder="Explore"
         ></SelectOne>
       </ComparisonComponent>
     </ComparisionContainer>
@@ -1042,7 +1046,7 @@ function TrackButtonExpandedContent(props: TrackButtonExpandedContentProps) {
           opacity: 0.8,
         }}
       >
-        Select an option:
+        Pick what you can do for this amount:
       </p>
       <div className="buttons">
         {props.scenarios.map((scenario, index) => (
@@ -1119,7 +1123,7 @@ const ComparisonComponent = styled.div`
     text-align: center;
     border-radius: 0;
     box-shadow: none;
-    background-position-y: 21px;
+    background-position-y: 31px;
     z-index: 1;
     color: inherit !important;
 


### PR DESCRIPTION
This PR updates the RoadsVsTransit view to display dollar amounts instead of mile-based options in the tab interface, improving user clarity about the monetary equivalents of road infrastructure investments.

- Changed option display from miles to dollar amounts (e.g., "$1.5 million" instead of "1.5 miles")
- Enhanced UI clarity with updated text labels and navigation indicators
- Improved visual styling for navigation buttons and page indicators


<img width="283" height="418" alt="image" src="https://github.com/user-attachments/assets/a7f7bba8-7f97-4a10-977f-eec80a78415e" />
