### PR TITLE
feat(frontend): clairify the time window for boardings and alightings

### DIFF
--- a/frontend/src/components/sections/ServiceStatistics.tsx
+++ b/frontend/src/components/sections/ServiceStatistics.tsx
@@ -69,13 +69,24 @@ export function ServiceStatistics() {
           <Statistic.Number
             wrap
             label="Boardings"
-            description="Sum of passengers getting on a bus"
+            description={(() => {
+              if (data?.length === 1) {
+                const year = data[0]?.__year;
+                const quarter = data[0]?.__quarter;
+                if (year && quarter) {
+                  const season = `${quarter === 'Q2' ? 'January-June' : 'July-December'} ${year}`;
+                  return `Passengers getting on a bus ${season}`;
+                }
+              }
+
+              return 'Sum of passengers getting on a bus during the specified time period';
+            })()}
             data={data?.map((area) => {
               const boardings = area.ridership?.area.map((stop) => stop.boarding) || [];
               const boardingsTotal = boardings.reduce((sum, value) => sum + (value || 0), 0);
 
               return {
-                label: area.__label,
+                label: area.__label.replace('Q2', 'Jan-June').replace('Q4', 'July-Dec'),
                 value: boardingsTotal,
               };
             })}
@@ -85,13 +96,24 @@ export function ServiceStatistics() {
           <Statistic.Number
             wrap
             label="Alightings"
-            description="Sum of passengers getting off a bus"
+            description={(() => {
+              if (data?.length === 1) {
+                const year = data[0]?.__year;
+                const quarter = data[0]?.__quarter;
+                if (year && quarter) {
+                  const season = `${quarter === 'Q2' ? 'January-June' : 'July-December'} ${year}`;
+                  return `Passengers getting off a bus ${season}`;
+                }
+              }
+
+              return 'Sum of passengers getting off a bus during the specified time period';
+            })()}
             data={data?.map((area) => {
               const alightings = area.ridership?.area.map((stop) => stop.alighting) || [];
               const alightingsTotal = alightings.reduce((sum, value) => sum + (value || 0), 0);
 
               return {
-                label: area.__label,
+                label: area.__label.replace('Q2', 'Jan-June').replace('Q4', 'July-Dec'),
                 value: alightingsTotal,
               };
             })}


### PR DESCRIPTION
Since the boardings and alightings counts are based on halfves of the year despite replica being based on Q2 and Q4, we now specify the month ranges.

<img width="252" height="150" alt="image" src="https://github.com/user-attachments/assets/e619c635-1cec-49ed-9c01-fff61ea7780c" />

<img width="254" height="268" alt="image" src="https://github.com/user-attachments/assets/634fa490-2fef-43b8-8316-099118912659" />

