### PR TITLE
feat(frontend): move link to tab3 from work and school sections to service stats sections

### DIFF
--- a/frontend/src/components/sections/Coverage.tsx
+++ b/frontend/src/components/sections/Coverage.tsx
@@ -1,13 +1,16 @@
-import { useSearchParams } from 'react-router';
+import { useLocation, useSearchParams } from 'react-router';
 import { flatSectionBundleIds } from '.';
 import { useAppData, useSectionsVisibility, useToggleSectionItemVisibility } from '../../hooks';
 import { notEmpty, shouldRenderStatistic } from '../../utils';
-import { Section, Statistic } from '../common';
+import { Button, Section, SectionEntry, Statistic } from '../common';
+import { StatisticContainer } from '../common/Statistic/StatisticContainer';
+import { TAB_3_FRAGMENT } from '../navigation';
 import { useComparisonModeState } from '../options';
 
 export function Coverage() {
   const { scenarios } = useAppData();
   const { data: scenariosData } = scenarios;
+  const { search } = useLocation();
 
   const [isComparing] = useComparisonModeState();
   const [searchParams] = useSearchParams();
@@ -19,7 +22,7 @@ export function Coverage() {
     selectedRouteIds.includes(future.__routeId)
   );
 
-  const [visibleSections] = useSectionsVisibility();
+  const [visibleSections, , visibleTabs] = useSectionsVisibility();
   const { editMode, handleClick } = useToggleSectionItemVisibility('Future.Coverage');
   const shouldRender = shouldRenderStatistic.bind(
     null,
@@ -27,6 +30,20 @@ export function Coverage() {
     flatSectionBundleIds['Future.Coverage'],
     editMode
   );
+
+  const jobAccessSearch = (() => {
+    const currentSearchParams = new URLSearchParams(search);
+
+    const selectedAreas = currentSearchParams.get('areas')?.split(',').filter(notEmpty) || [];
+    const selectedSeasons = currentSearchParams.get('seasons')?.split(',').filter(notEmpty) || [];
+
+    const selectedSeasonAreas = selectedAreas.flatMap((area) => {
+      return selectedSeasons.map((season) => `${area}::${season}`);
+    });
+
+    currentSearchParams.set('jobAreas', selectedSeasonAreas.join(','));
+    return currentSearchParams.toString() ? `?${currentSearchParams.toString()}` : '';
+  })();
 
   return (
     <Section title="Coverage">
@@ -74,6 +91,23 @@ export function Coverage() {
         unit="square miles"
         onClick={handleClick('cov')}
       />
+      {shouldRender('jadl') && (!visibleTabs || visibleTabs.includes(TAB_3_FRAGMENT)) ? (
+        <SectionEntry f={{ gridColumn: 'span 2' }}>
+          <StatisticContainer
+            onClick={handleClick('jadl')}
+            style={{ opacity: shouldRender('jadl') === 'partial' ? 0.5 : 1 }}
+          >
+            <div>
+              <div style={{ fontSize: '0.875rem' }}>
+                What sectors could be served by this new route?
+              </div>
+              <Button href={'#/job-access' + jobAccessSearch}>
+                Explore industry/sector of employment
+              </Button>
+            </div>
+          </StatisticContainer>
+        </SectionEntry>
+      ) : null}
     </Section>
   );
 }

--- a/frontend/src/components/sections/WorkAndSchool2.tsx
+++ b/frontend/src/components/sections/WorkAndSchool2.tsx
@@ -1,15 +1,13 @@
-import { useLocation, useSearchParams } from 'react-router';
+import { useSearchParams } from 'react-router';
 import { flatSectionBundleIds } from '.';
 import { useAppData, useSectionsVisibility, useToggleSectionItemVisibility } from '../../hooks';
 import { notEmpty, shouldRenderStatistic, toTidyNominal } from '../../utils';
-import { Button, Section, SectionEntry, Statistic } from '../common';
-import { TAB_3_FRAGMENT } from '../navigation';
+import { Section, Statistic } from '../common';
 import { useComparisonModeState } from '../options';
 
 export function WorkAndSchool2() {
   const { scenarios } = useAppData();
   const { data: scenariosData } = scenarios;
-  const { search } = useLocation();
 
   const [isComparing] = useComparisonModeState();
   const [searchParams] = useSearchParams();
@@ -21,7 +19,7 @@ export function WorkAndSchool2() {
     selectedRouteIds.includes(future.__routeId)
   );
 
-  const [visibleSections, , visibleTabs] = useSectionsVisibility();
+  const [visibleSections] = useSectionsVisibility();
   const { editMode, handleClick } = useToggleSectionItemVisibility('Future.WorkAndSchoolCommute');
   const shouldRender = shouldRenderStatistic.bind(
     null,
@@ -29,12 +27,6 @@ export function WorkAndSchool2() {
     flatSectionBundleIds['Future.WorkAndSchoolCommute'],
     editMode
   );
-
-  const jobAccessSearch = (() => {
-    const currentSearchParams = new URLSearchParams(search);
-    currentSearchParams.set('jobAreas', selectedRouteIds.map((id) => `${id}::future`).join(','));
-    return currentSearchParams.toString() ? `?${currentSearchParams.toString()}` : '';
-  })();
 
   return (
     <Section title="Work and School" key={1}>
@@ -86,19 +78,6 @@ export function WorkAndSchool2() {
           return { label: __routeId, value: medianDuration.toFixed(2) };
         })}
       />
-      {!visibleTabs || visibleTabs.includes(TAB_3_FRAGMENT) ? (
-        <SectionEntry
-          s={{ gridColumn: '1 / 3' }}
-          m={{ gridColumn: '1 / 4' }}
-          l={{ gridColumn: '1 / 5' }}
-        >
-          <div>
-            <Button href={'#/job-access' + jobAccessSearch}>
-              Explore industry/sector of employment
-            </Button>
-          </div>
-        </SectionEntry>
-      ) : null}
       <Statistic.Figure
         wrap={{ f: { gridColumn: '1 / -1' } }}
         label="Current commute travel modes"

--- a/frontend/src/components/sections/WorkAndSchoolCommute.tsx
+++ b/frontend/src/components/sections/WorkAndSchoolCommute.tsx
@@ -1,17 +1,14 @@
-import { useLocation } from 'react-router';
 import { flatSectionBundleIds } from '.';
 import { useAppData, useSectionsVisibility, useToggleSectionItemVisibility } from '../../hooks';
-import { notEmpty, shouldRenderStatistic } from '../../utils';
-import { Button, Section, SectionEntry, Statistic } from '../common';
+import { shouldRenderStatistic } from '../../utils';
+import { Section, SectionEntry, Statistic } from '../common';
 import { StatisticContainer } from '../common/Statistic/StatisticContainer';
-import { TAB_3_FRAGMENT } from '../navigation';
 import { SelectTravelMethod } from '../options';
 
 export function WorkAndSchoolCommute() {
   const { data, travelMethodList } = useAppData();
-  const { search } = useLocation();
 
-  const [visibleSections, , visibleTabs] = useSectionsVisibility();
+  const [visibleSections] = useSectionsVisibility();
   const { editMode, handleClick } = useToggleSectionItemVisibility('WorkAndSchoolCommute');
   const shouldRender = shouldRenderStatistic.bind(
     null,
@@ -19,20 +16,6 @@ export function WorkAndSchoolCommute() {
     flatSectionBundleIds.WorkAndSchoolCommute,
     editMode
   );
-
-  const jobAccessSearch = (() => {
-    const currentSearchParams = new URLSearchParams(search);
-
-    const selectedAreas = currentSearchParams.get('areas')?.split(',').filter(notEmpty) || [];
-    const selectedSeasons = currentSearchParams.get('seasons')?.split(',').filter(notEmpty) || [];
-
-    const selectedSeasonAreas = selectedAreas.flatMap((area) => {
-      return selectedSeasons.map((season) => `${area}::${season}`);
-    });
-
-    currentSearchParams.set('jobAreas', selectedSeasonAreas.join(','));
-    return currentSearchParams.toString() ? `?${currentSearchParams.toString()}` : '';
-  })();
 
   return (
     <Section title="Commutes to Work and School" shortTitle="Work & School">
@@ -126,19 +109,6 @@ export function WorkAndSchoolCommute() {
           return { label: area.__label, value: medianDuration.toFixed(2) };
         })}
       />
-      {!visibleTabs || visibleTabs.includes(TAB_3_FRAGMENT) ? (
-        <SectionEntry
-          s={{ gridColumn: '1 / 3' }}
-          m={{ gridColumn: '1 / 4' }}
-          l={{ gridColumn: '1 / 5' }}
-        >
-          <div>
-            <Button href={'#/job-access' + jobAccessSearch}>
-              Explore industry/sector of employment
-            </Button>
-          </div>
-        </SectionEntry>
-      ) : null}
     </Section>
   );
 }


### PR DESCRIPTION
<img width="519" height="615" alt="image" src="https://github.com/user-attachments/assets/38d4a049-5d76-432b-ad55-0b7123d71b81" />
<img width="516" height="323" alt="image" src="https://github.com/user-attachments/assets/84173193-4a2e-4b60-aded-21912e0f02a1" />
