### PR TITLE
feat: ensure that bus stops are visible when highlighted, regardless of the layer's minimum scale

### DIFF
--- a/frontend/src/views/RoadsVsTransit.tsx
+++ b/frontend/src/views/RoadsVsTransit.tsx
@@ -549,6 +549,25 @@ async function showFeaturesOnMap(
             });
           }
 
+          // also temporarily modify the min scale for the bus stops layers so that the bus stops are visible
+          const oldMinScales = busStopsLayers
+            .filter((layer): layer is __esri.GeoJSONLayer => layer.type === 'geojson')
+            .map((layer) => {
+              const oldMinScale = layer.minScale;
+              layer.minScale = 0;
+
+              // return information about the old scale so we can restore it later
+              return { id: layer.id, oldMinScale };
+            });
+          registerCleanupFunction(() => {
+            oldMinScales.forEach(({ id, oldMinScale }) => {
+              const layer = mapView?.map?.findLayerById(id) as __esri.GeoJSONLayer | undefined;
+              if (layer) {
+                layer.minScale = oldMinScale;
+              }
+            });
+          });
+
           // request zoom to the highlighted features
           return foundLayers.map(({ layerView, targetQuery }) => ({
             id: layerView.layer.id,


### PR DESCRIPTION
This change temporarily sets the minimum scale for bus stops to zero when any bus stop is highlighted, which ensures that the highlighted bus stops are always visible.

Previously, if the map was too small, the bus stop icons would disapear even when hihglighted. They still disappear when the map is too small and no bus stop is highlighted.