### PR TITLE
fix: do not render expanded content for scenario bubbles that are not expanded

### DIFF
--- a/frontend/src/views/RoadsVsTransit.tsx
+++ b/frontend/src/views/RoadsVsTransit.tsx
@@ -708,14 +708,16 @@ function Comparison(props: { title: string; mapView: __esri.MapView | null }) {
                   : '1000ms opacity',
             }}
           >
-            <TrackButtonExpandedContent
-              optionLabel={optionLabel.replace('.0 million', ' million')}
-              scenarios={buttonScenarios}
-              transitioning={transitioning}
-              mapView={props.mapView}
-              searchParams={searchParams}
-              setSearchParams={setSearchParams}
-            />
+            {selectedIndex === index ? (
+              <TrackButtonExpandedContent
+                optionLabel={optionLabel.replace('.0 million', ' million')}
+                scenarios={buttonScenarios}
+                transitioning={transitioning}
+                mapView={props.mapView}
+                searchParams={searchParams}
+                setSearchParams={setSearchParams}
+              />
+            ) : null}
           </ButtonInterior>
         </>
       ),


### PR DESCRIPTION
This was causing the selected feature index and selected scenario index to apply for each selected scenario group bubble. That meant that extra features were being highlighted!

Fixes #277