### PR TITLE
fix: ensure map tab on essential services is labeled "map" instead of "tab 1"

### DIFF
--- a/frontend/src/views/EssentialServicesAccess.tsx
+++ b/frontend/src/views/EssentialServicesAccess.tsx
@@ -57,8 +57,8 @@ export function EssentialServicesAccess() {
       sectionsHeader={<SectionsHeader />}
       sidebar={<Sidebar />}
       map={
-        <div style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
-          <div style={{ height: '100%' }} title="Map">
+        <div style={{ height: '100%', display: 'flex', flexDirection: 'column' }} title="Map">
+          <div style={{ height: '100%' }}>
             <Map
               layers={[
                 ...networkSegments,


### PR DESCRIPTION
<img width="502" height="643" alt="image" src="https://github.com/user-attachments/assets/b66344bc-4638-420d-be75-11280c2a0d63" />
