### PR TITLE
feat: add option to replace built-in FAQs with external FAQs

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -124,6 +124,18 @@ To display a home button that directs users to a custom home page or landing pag
 
 A home button will appear in the dashboard's navigation.
 
+The user's current search parameters will be preserved when navigating to the home page.
+
+## Replace the FAQs link
+
+To replace the default FAQs link in the dashboard with a link to an external help page, you can set the `data-help-path` attribute on the `gcmd-root` div. For example:
+
+```html
+<div id="gcmd-root" data-help-path="/custom-help-page"></div>
+```
+
+This will update the FAQs link in the dashboard's navigation to point to the specified help page. The user's current search parameters will be preserved when navigating to the help page.
+
 ## Important cache considerations
 
 The `index.html` and `index.js` files must not be cached by browsers or CDNs. These files contain references to the unique asset paths generated during the build process. If these files are cached, users may receive outdated references to assets that no longer exist, leading to broken functionality. To prevent caching issues, ensure that your server or CDN is configured to set appropriate cache-control headers for these files, such as `Cache-Control: no-cache` or `Cache-Control: max-age=0, must-revalidate`.

--- a/frontend/src/components/navigation/AppNavigation.tsx
+++ b/frontend/src/components/navigation/AppNavigation.tsx
@@ -23,6 +23,15 @@ export function AppNavigation() {
     window.location.href = homePath + search;
   }
 
+  const externalFAQsPath = rootElement?.getAttribute('data-help-path') || undefined;
+  function navigateToFAQs() {
+    if (externalFAQsPath) {
+      window.location.href = externalFAQsPath + search;
+    } else {
+      handleClick(FAQ_TAB_FRAGMENT + search);
+    }
+  }
+
   const handleClick =
     (to: string) => (evt: React.MouseEvent<HTMLAnchorElement | HTMLButtonElement, MouseEvent>) => {
       evt.preventDefault();
@@ -147,8 +156,8 @@ export function AppNavigation() {
                 </Button>
               )}
               <Button
-                href={'#' + FAQ_TAB_FRAGMENT + search}
-                onClick={handleClick(FAQ_TAB_FRAGMENT + search)}
+                href={(externalFAQsPath || '#' + FAQ_TAB_FRAGMENT) + search}
+                onClick={navigateToFAQs}
               >
                 FAQs
               </Button>
@@ -268,9 +277,9 @@ export function AppNavigation() {
           <div className="spacer" style={{ flexGrow: 1 }}></div>
           <Tab
             label={isNarrowerDesktop ? '' : 'FAQs'}
-            href={'#' + FAQ_TAB_FRAGMENT + search}
+            href={(externalFAQsPath || '#' + FAQ_TAB_FRAGMENT) + search}
             isActive={pathname === FAQ_TAB_FRAGMENT}
-            onClick={handleClick(FAQ_TAB_FRAGMENT + search)}
+            onClick={navigateToFAQs}
             iconLeft={
               <svg viewBox="0 0 24 24">
                 <path

--- a/frontend/src/views/FAQ.tsx
+++ b/frontend/src/views/FAQ.tsx
@@ -2,13 +2,22 @@ import styled from '@emotion/styled';
 import DOMPurify from 'dompurify';
 import { marked } from 'marked';
 import { useEffect, useState } from 'react';
+import { useLocation } from 'react-router';
 import bannerImageSrc from '../assets/images/faq-banner.jpg';
 import { CoreFrame } from '../components';
 import { AppNavigation } from '../components/navigation';
 import { getDataOriginAndPath } from '../hooks/useAppData';
 
 export function FAQ() {
+  const { search } = useLocation();
   const { dataOrigin, dataPath } = getDataOriginAndPath();
+
+  // redirect to external FAQs if the data-help-path attribute is specified
+  const rootElement = document.getElementById('gcmd-root');
+  const externalFAQsPath = rootElement?.getAttribute('data-help-path') || undefined;
+  if (externalFAQsPath) {
+    window.location.href = externalFAQsPath + search;
+  }
 
   const [html, setHtml] = useState('');
   const [loading, setLoading] = useState(true);


### PR DESCRIPTION
When this option is enabled, the FAQs link will be replaced with the external path, and the FAQs view will redirect to the external path. The current search portion of the URL will always be appended to the redirected URL.

Closes #268.