### PR TITLE
feat: use blank content when the current fragment is the home/landing page

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -136,6 +136,75 @@ To replace the default FAQs link in the dashboard with a link to an external hel
 
 This will update the FAQs link in the dashboard's navigation to point to the specified help page. The user's current search parameters will be preserved when navigating to the help page.
 
+## Control the dashboard's root element position and size based on the current tab
+
+The dashboard adds a class to its root element (element with ID `gcmd-root`) based on the current tab.
+
+| Tab Name                                                | Class Name                  |
+| ------------------------------------------------------- | --------------------------- |
+| Home (when `data-home-path` is specified)               | `fragment--`                |
+| General Access (when `data-home-path` is specified)     | `fragment--general`         |
+| General Access (when `data-home-path` is not specified) | `fragment--`                |
+| Future Opportunities                                    | `fragment--future`          |
+| Job Access                                              | `fragment--job-access`      |
+| Access to Essential Services                            | `fragment--services-access` |
+| Roads or Transit?                                       | `fragment--roads`           |
+| FAQs                                                    | `fragment--faq`             |
+
+An example use-case for this feature is to embed the dashboard into an existing webpage with other content, and to have the dashboard expand to fullscreen when the user navigates to a tab other than the home tab. This can be achieved with the following CSS:
+
+<details>
+<summary>Example CSS for fullscreen mode on non-home tabs</summary>
+
+```css
+:root {
+  --body-margin: 10px; /* adjust this to match your webpage's padding around the dashboard */
+}
+
+#gcmd-root {
+  background: white;
+  font-family: 'Poppins', sans-serif;
+
+  /* ensure that the tab bar always uses the full width fo the viewport */
+  position: relative;
+  width: 100dvw;
+  left: calc(var(--body-margin) * -1);
+
+  /* enable transition animations between the home tab size and the other tabs size */
+  transition: all 280ms ease;
+  transition-behavior: allow-discrete;
+  height: calc-size(min-content, size);
+}
+
+/* switch to fullscreen mode when not on home tab */
+#gcmd-root:not(.fragment--) {
+  position: absolute;
+  inset: 0;
+  height: 100dvh;
+}
+
+/* disable body scrolling when we are in fullscreen mode */
+body:has(#gcmd-root[class*='fragment--']:not(.fragment--)) {
+  overflow: hidden;
+}
+
+/* put the mobile-mode nav bar at the bottom of the page when on the home screen */
+@media (max-width: 899px) {
+  #gcmd-root.fragment-- {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: auto;
+  }
+  body {
+    padding-bottom: 70px;
+  }
+}
+```
+
+</details>
+
 ## Important cache considerations
 
 The `index.html` and `index.js` files must not be cached by browsers or CDNs. These files contain references to the unique asset paths generated during the build process. If these files are cached, users may receive outdated references to assets that no longer exist, leading to broken functionality. To prevent caching issues, ensure that your server or CDN is configured to set appropriate cache-control headers for these files, such as `Cache-Control: no-cache` or `Cache-Control: max-age=0, must-revalidate`.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,9 +3,11 @@ import { useEffect, useMemo, useState } from 'react';
 import { Route, Routes, useLocation, useNavigate, useSearchParams } from 'react-router';
 import { Button, CoreFrameContext, createCoreFrameContextValue } from './components';
 import {
+  AppNavigation,
   COMPONENTS_ROUTE_FRAGMENT,
   FAQ_TAB_FRAGMENT,
   LANDING_PAGE_FRAGMENT,
+  TAB_1_ALT_FRAGMENT,
   TAB_1_FRAGMENT,
   TAB_2_FRAGMENT,
   TAB_3_FRAGMENT,
@@ -14,7 +16,7 @@ import {
 } from './components/navigation';
 import { useSectionsVisibility } from './hooks';
 import { AppDataContext, AppDataHookParameters, createAppDataContext } from './hooks/useAppData';
-import { notEmpty } from './utils';
+import { getRootAttributes, notEmpty } from './utils';
 import {
   DevModeComponentsAll,
   EssentialServicesAccess,
@@ -29,6 +31,7 @@ export default function App() {
   const [searchParams, setSearchParams] = useSearchParams();
   const { pathname } = useLocation();
   const [, , visibleTabs] = useSectionsVisibility();
+  const { homePath } = getRootAttributes();
 
   const comparisonEnabled = useMemo(() => {
     return searchParams.get('compare') === '1';
@@ -212,6 +215,26 @@ export default function App() {
     setSearchParams(searchParams, { replace: true });
   };
 
+  // Add a class to the root element that matches the current path fragment for
+  // easier external styling based on route.
+  // Format: fragment-{path-fragment}, with slashes replaced by dashes.
+  // For example, /future becomes fragment--future
+  useEffect(() => {
+    const rootElement = document.getElementById('gcmd-root');
+    if (!rootElement) return;
+
+    const fragmentClass = pathname.split('/').filter(notEmpty).join('-');
+
+    // remove any existing fragment classes
+    Array.from(rootElement.classList)
+      .filter((cls) => cls.startsWith('fragment-'))
+      .forEach((cls) => rootElement.classList.remove(cls));
+
+    if (fragmentClass) {
+      rootElement.classList.add(`fragment-${fragmentClass}`);
+    }
+  }, [pathname]);
+
   return (
     <AppWrapper>
       <AppDataContext.Provider
@@ -255,8 +278,14 @@ export default function App() {
           {import.meta.env.DEV ? <PlaceholderGreenvilleConnectsWebsiteHeader /> : null}
 
           <Routes>
+            {!!homePath ? (
+              <Route path={LANDING_PAGE_FRAGMENT} element={<AppNavigation />}></Route>
+            ) : null}
             {!visibleTabs || visibleTabs.includes(TAB_1_FRAGMENT) ? (
-              <Route index Component={GeneralAccess} />
+              <>
+                {!homePath && <Route index Component={GeneralAccess} />}
+                {!!homePath && <Route path={TAB_1_ALT_FRAGMENT} index Component={GeneralAccess} />}
+              </>
             ) : null}
             {!visibleTabs || visibleTabs.includes(TAB_2_FRAGMENT) ? (
               <Route path={TAB_2_FRAGMENT} Component={FutureOpportunities} />
@@ -298,6 +327,7 @@ function Error404() {
   const validPaths = [
     LANDING_PAGE_FRAGMENT,
     TAB_1_FRAGMENT,
+    TAB_1_ALT_FRAGMENT,
     TAB_2_FRAGMENT,
     TAB_3_FRAGMENT,
     TAB_4_FRAGMENT,

--- a/frontend/src/components/navigation/AppNavigation.tsx
+++ b/frontend/src/components/navigation/AppNavigation.tsx
@@ -2,9 +2,11 @@ import styled from '@emotion/styled';
 import { useEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 import { useSectionsVisibility } from '../../hooks';
+import { getRootAttributes } from '../../utils';
 import { Button, NavBar, NavBarItem, Tab, Tabs } from '../common';
 import {
   FAQ_TAB_FRAGMENT,
+  LANDING_PAGE_FRAGMENT,
   TAB_1_FRAGMENT,
   TAB_2_FRAGMENT,
   TAB_3_FRAGMENT,
@@ -16,14 +18,12 @@ export function AppNavigation() {
   const { pathname, search } = useLocation();
   const navigate = useNavigate();
   const [, , visibleTabs] = useSectionsVisibility();
+  const { homePath, externalFAQsPath } = getRootAttributes();
 
-  const rootElement = document.getElementById('gcmd-root');
-  const homePath = rootElement?.getAttribute('data-home-path') || undefined;
   function goHome() {
     window.location.href = homePath + search;
   }
 
-  const externalFAQsPath = rootElement?.getAttribute('data-help-path') || undefined;
   function navigateToFAQs() {
     if (externalFAQsPath) {
       window.location.href = externalFAQsPath + search;
@@ -170,6 +170,7 @@ export function AppNavigation() {
             <Tab
               label={''}
               href={homePath + search}
+              isActive={pathname === LANDING_PAGE_FRAGMENT}
               onClick={goHome}
               iconLeft={
                 <svg viewBox="0 0 24 24">
@@ -185,7 +186,9 @@ export function AppNavigation() {
             <Tab
               label="General Access"
               href={'#' + TAB_1_FRAGMENT + search}
-              isActive={pathname === TAB_1_FRAGMENT}
+              isActive={
+                pathname === TAB_1_FRAGMENT || (!homePath && pathname === LANDING_PAGE_FRAGMENT)
+              }
               onClick={handleClick(TAB_1_FRAGMENT + search)}
               iconLeft={
                 !isNarrowerDesktop && (

--- a/frontend/src/components/navigation/constants.ts
+++ b/frontend/src/components/navigation/constants.ts
@@ -1,5 +1,10 @@
+import { getRootAttributes } from '../../utils';
+
+const { homePath } = getRootAttributes();
+
 export const LANDING_PAGE_FRAGMENT = '/';
-export const TAB_1_FRAGMENT = '/';
+export const TAB_1_ALT_FRAGMENT = '/general';
+export const TAB_1_FRAGMENT = homePath ? TAB_1_ALT_FRAGMENT : '/';
 export const TAB_2_FRAGMENT = '/future';
 export const TAB_3_FRAGMENT = '/job-access';
 export const TAB_4_FRAGMENT = '/services-access';

--- a/frontend/src/hooks/useAppData.ts
+++ b/frontend/src/hooks/useAppData.ts
@@ -1,7 +1,7 @@
 import type { Style as MapboxStyle, VectorSource as MapboxVectorSource } from 'mapbox-gl';
 import { createContext, useContext, useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router';
-import { generateHash, inflateResponse, notEmpty } from '../utils';
+import { generateHash, getRootAttributes, inflateResponse, notEmpty } from '../utils';
 
 export function createAppDataContext(
   areas: AppDataHookParameters['areas'],
@@ -28,14 +28,6 @@ export function _useAppDataContext() {
   return useContext(AppDataContext);
 }
 
-export function getDataOriginAndPath() {
-  const rootElement = document.getElementById('gcmd-root');
-
-  const dataOrigin = rootElement?.getAttribute('data-origin') || __GCMD_DATA_ORIGIN__;
-  const dataPath = rootElement?.getAttribute('data-path') || __GCMD_DATA_PATH__;
-  return { dataOrigin, dataPath };
-}
-
 export interface AppDataHookParameters {
   areas: string[];
   seasons: ['Q2' | 'Q4', number][];
@@ -50,7 +42,7 @@ export interface AppDataHookParameters {
 
 function _useAppData({ areas, seasons, travelMethod }: AppDataHookParameters) {
   const [searchParams, setSearchParams] = useSearchParams();
-  const { dataOrigin, dataPath } = getDataOriginAndPath();
+  const { dataOrigin, dataPath } = getRootAttributes();
 
   const [areasList, setAreasList] = useState<string[]>([]);
   useEffect(() => {
@@ -536,7 +528,7 @@ function handleError(
  * Fetches the core census data that is used across all areas and seasons.
  */
 function getCensusData() {
-  const { dataOrigin, dataPath } = getDataOriginAndPath();
+  const { dataOrigin, dataPath } = getRootAttributes();
 
   const paths = {
     households: dataOrigin + dataPath + `/census_acs_5year/B08201/time_series.json.deflate`,
@@ -585,7 +577,7 @@ function getCensusData() {
  * Provides promises that fetch the data related to Greenlink service.
  */
 function getGreenlinkPromises(seasons: AppDataHookParameters['seasons']) {
-  const { dataOrigin, dataPath } = getDataOriginAndPath();
+  const { dataOrigin, dataPath } = getRootAttributes();
 
   const allPromises = seasons.map(([__quarter, __year]) => {
     const gtfsFolder = dataOrigin + dataPath + `/greenlink_gtfs/${__year}/${__quarter}`;
@@ -647,7 +639,7 @@ function getEssentialServicesPromises(
   areas: AppDataHookParameters['areas'],
   seasons: AppDataHookParameters['seasons']
 ) {
-  const { dataOrigin, dataPath } = getDataOriginAndPath();
+  const { dataOrigin, dataPath } = getRootAttributes();
 
   const allPromises = seasons.flatMap(([__quarter, __year]) => {
     return areas.map((__area) => {
@@ -751,7 +743,7 @@ function constructReplicaPaths(
   seasons: AppDataHookParameters['seasons'],
   travelMethod?: AppDataHookParameters['travelMethod']
 ) {
-  const { dataOrigin, dataPath } = getDataOriginAndPath();
+  const { dataOrigin, dataPath } = getRootAttributes();
 
   return areas.flatMap((area) => {
     return seasons.map(([quarter, year]) => {
@@ -794,7 +786,7 @@ function constructReplicaPaths(
  * @param replicaPaths - the returned value of `constructReplicaPaths`
  */
 function constructReplicaPromises(replicaPaths: ReturnType<typeof constructReplicaPaths>) {
-  const { dataOrigin, dataPath } = getDataOriginAndPath();
+  const { dataOrigin, dataPath } = getRootAttributes();
 
   return replicaPaths.map(({ __area, __displayArea, __year, __quarter, __label, ...paths }) => {
     return {
@@ -852,7 +844,7 @@ function constructReplicaPromises(replicaPaths: ReturnType<typeof constructRepli
 }
 
 function constructScenarioDataPromises(futureRoutesList: string[]) {
-  const { dataOrigin, dataPath } = getDataOriginAndPath();
+  const { dataOrigin, dataPath } = getRootAttributes();
 
   const futureRoutesPromises = futureRoutesList.map((routeId) => {
     const folderPath = dataOrigin + dataPath + '/future_routes/' + routeId;

--- a/frontend/src/utils/getRootAttributes.ts
+++ b/frontend/src/utils/getRootAttributes.ts
@@ -1,0 +1,61 @@
+/**
+ * Provides access to known attributes on the root element of the app.
+ *
+ * These attributes are consumer-provided options that control how the
+ * app behaves.
+ */
+export function getRootAttributes() {
+  const rootElement = document.getElementById('gcmd-root');
+
+  const homePathAttrValue = rootElement?.getAttribute('data-home-path') || undefined;
+  const homePathAdapted = ensureTrailingHashSlash(homePathAttrValue);
+  const homePath =
+    homePathAdapted === './#/'
+      ? window.location.pathname + window.location.search + '#/'
+      : homePathAdapted; // for data-home-path=".", resolve to current path
+
+  const helpPathAttrValue = rootElement?.getAttribute('data-help-path') || undefined;
+  const helpPathAdapted = ensureTrailingHashSlash(helpPathAttrValue);
+  const helpPath =
+    helpPathAdapted === './#/'
+      ? window.location.pathname + window.location.search + '#/'
+      : helpPathAdapted; // for data-help-path=".", resolve to current path
+
+  const dataOriginAttrValue = rootElement?.getAttribute('data-origin') || __GCMD_DATA_ORIGIN__;
+  const dataPathAttrValue = rootElement?.getAttribute('data-path') || __GCMD_DATA_PATH__;
+
+  return {
+    homePath,
+    externalFAQsPath: helpPath,
+    dataOrigin: dataOriginAttrValue,
+    dataPath: dataPathAttrValue,
+  };
+}
+
+function ensureTrailingHashSlash(
+  path: string | undefined
+): `${string}/#/` | `${string}#/` | undefined {
+  if (!path) return undefined;
+
+  const hasQuery = path.includes('?');
+  const marker = hasQuery ? '#/' : '/#/';
+  const splitOn = hasQuery ? '#/' : '/#/';
+
+  if (path.endsWith(marker)) {
+    return path as `${string}#/` | `${string}/#/`;
+  }
+
+  if (path.endsWith(marker.slice(0, -1))) {
+    return `${path}/` as `${string}#/` | `${string}/#/`;
+  }
+
+  if (path.includes(splitOn)) {
+    return `${path.split(splitOn)[0]}${marker}` as `${string}#/` | `${string}/#/`;
+  }
+
+  if (hasQuery && path.includes('#')) {
+    return `${path.split('#')[0]}#/` as `${string}#/`;
+  }
+
+  return `${path}${marker}` as `${string}#/` | `${string}/#/`;
+}

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -2,6 +2,7 @@ export { createPopupRoot } from './createPopupRoot';
 export { debounce } from './debounce';
 export { flattenObject } from './flattenObject';
 export { generateHash } from './generateHash';
+export { getRootAttributes } from './getRootAttributes';
 export { hasKey } from './hasKey';
 export { inflateResponse } from './inflateResponse';
 export { isGeoJSON } from './isGeoJson';

--- a/frontend/src/views/FAQ.tsx
+++ b/frontend/src/views/FAQ.tsx
@@ -6,15 +6,13 @@ import { useLocation } from 'react-router';
 import bannerImageSrc from '../assets/images/faq-banner.jpg';
 import { CoreFrame } from '../components';
 import { AppNavigation } from '../components/navigation';
-import { getDataOriginAndPath } from '../hooks/useAppData';
+import { getRootAttributes } from '../utils';
 
 export function FAQ() {
   const { search } = useLocation();
-  const { dataOrigin, dataPath } = getDataOriginAndPath();
 
   // redirect to external FAQs if the data-help-path attribute is specified
-  const rootElement = document.getElementById('gcmd-root');
-  const externalFAQsPath = rootElement?.getAttribute('data-help-path') || undefined;
+  const { externalFAQsPath, dataOrigin, dataPath } = getRootAttributes();
   if (externalFAQsPath) {
     window.location.href = externalFAQsPath + search;
   }
@@ -23,7 +21,10 @@ export function FAQ() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
   useEffect(() => {
-    fetch(dataOrigin + dataPath + '/faq.md', { redirect: 'error' })
+    fetch(dataOrigin + dataPath + '/faq.md', {
+      redirect: 'error',
+      headers: { Accept: 'text/markdown, text/x-markdowm, text/plain' },
+    })
       .then((response) => {
         if (!response.ok) {
           throw new Error('Failed to load FAQ content', { cause: response.statusText });


### PR DESCRIPTION
This change makes it possible to only show the navigation bar when on the home page. For more info, please see this documentation excerpt:

## Control the dashboard's root element position and size based on the current tab

The dashboard adds a class to its root element (element with ID `gcmd-root`) based on the current tab.

| Tab Name                                                | Class Name                  |
| ------------------------------------------------------- | --------------------------- |
| Home (when `data-home-path` is specified)               | `fragment--`                |
| General Access (when `data-home-path` is specified)     | `fragment--general`         |
| General Access (when `data-home-path` is not specified) | `fragment--`                |
| Future Opportunities                                    | `fragment--future`          |
| Job Access                                              | `fragment--job-access`      |
| Access to Essential Services                            | `fragment--services-access` |
| Roads or Transit?                                       | `fragment--roads`           |
| FAQs                                                    | `fragment--faq`             |

An example use-case for this feature is to embed the dashboard into an existing webpage with other content, and to have the dashboard expand to fullscreen when the user navigates to a tab other than the home tab. This can be achieved with the following CSS:

<details>
<summary>Example CSS for fullscreen mode on non-home tabs</summary>

```css
:root {
  --body-margin: 10px; /* adjust this to match your webpage's padding around the dashboard */
}

#gcmd-root {
  background: white;
  font-family: 'Poppins', sans-serif;

  /* ensure that the tab bar always uses the full width fo the viewport */
  position: relative;
  width: 100dvw;
  left: calc(var(--body-margin) * -1);

  /* enable transition animations between the home tab size and the other tabs size */
  transition: all 280ms ease;
  transition-behavior: allow-discrete;
  height: calc-size(min-content, size);
}

/* switch to fullscreen mode when not on home tab */
#gcmd-root:not(.fragment--) {
  position: absolute;
  inset: 0;
  height: 100dvh;
}

/* disable body scrolling when we are in fullscreen mode */
body:has(#gcmd-root[class*='fragment--']:not(.fragment--)) {
  overflow: hidden;
}

/* put the mobile-mode nav bar at the bottom of the page when on the home screen */
@media (max-width: 899px) {
  #gcmd-root.fragment-- {
    position: fixed;
    bottom: 0;
    left: 0;
    width: 100%;
    height: auto;
  }
  body {
    padding-bottom: 70px;
  }
}
```

</details>